### PR TITLE
Added option to switch between silent/balanced mode when on battery/plugged

### DIFF
--- a/GHelper.csproj
+++ b/GHelper.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows10.0.17763.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UseWindowsForms>True</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -31,6 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="hidlibrary" Version="3.3.40" />
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="System.Management" Version="7.0.0" />
     <PackageReference Include="TaskScheduler" Version="2.10.1" />
   </ItemGroup>

--- a/Program.cs
+++ b/Program.cs
@@ -531,12 +531,14 @@ namespace GHelper
 
             settingsForm.VisualiseGPUAuto(config.getConfig("gpu_auto"));
             settingsForm.VisualiseScreenAuto(config.getConfig("screen_auto"));
+            settingsForm.VisualiseCPUAuto(config.getConfig("cpu_auto"));
 
             settingsForm.SetStartupCheck(scheduler.IsScheduled());
 
             bool isPlugged = (SystemInformation.PowerStatus.PowerLineStatus == PowerLineStatus.Online);
             settingsForm.AutoGPUMode(isPlugged ? 1 : 0);
             settingsForm.AutoScreen(isPlugged ? 1 : 0);
+            settingsForm.AutoCPUMode(isPlugged? 1 : 0);
 
             Application.Run();
 
@@ -573,6 +575,7 @@ namespace GHelper
                     {
                         settingsForm.AutoGPUMode(0);
                         settingsForm.AutoScreen(0);
+                        settingsForm.AutoCPUMode(0);
                     });
                     return;
                 case 88:  // Plugged
@@ -581,6 +584,7 @@ namespace GHelper
                     {
                         settingsForm.AutoGPUMode(1);
                         settingsForm.AutoScreen(1);
+                        settingsForm.AutoCPUMode(1);
                     });
                     return;
 

--- a/Settings.Designer.cs
+++ b/Settings.Designer.cs
@@ -57,6 +57,7 @@
             this.button60Hz = new System.Windows.Forms.Button();
             this.checkScreen = new System.Windows.Forms.CheckBox();
             this.checkBoost = new System.Windows.Forms.CheckBox();
+            this.checkCPU = new System.Windows.Forms.CheckBox();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
             this.label1 = new System.Windows.Forms.Label();
             this.comboKeyboard = new System.Windows.Forms.ComboBox();
@@ -331,6 +332,19 @@
             this.labelPerf.TabIndex = 13;
             this.labelPerf.Text = "Performance Mode";
             // 
+            // checkCPU
+            // 
+            this.checkCPU.AutoSize = true;
+            this.checkCPU.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.checkCPU.Location = new System.Drawing.Point(33, 221);
+            this.checkCPU.Margin = new System.Windows.Forms.Padding(4, 2, 4, 2);
+            this.checkCPU.Name = "checkCPU";
+            this.checkCPU.Size = new System.Drawing.Size(580, 36);
+            this.checkCPU.TabIndex = 20;
+            this.checkCPU.Text = "Set Silent on battery and Balanced when plugged";
+            this.checkCPU.UseVisualStyleBackColor = true;
+            this.checkCPU.CheckedChanged += new System.EventHandler(this.checkCPU_CheckedChanged);
+            // 
             // checkGPU
             // 
             this.checkGPU.AutoSize = true;
@@ -530,6 +544,7 @@
             this.Controls.Add(this.labelSreen);
             this.Controls.Add(this.buttonQuit);
             this.Controls.Add(this.checkGPU);
+            this.Controls.Add(this.checkCPU);
             this.Controls.Add(this.picturePerf);
             this.Controls.Add(this.labelPerf);
             this.Controls.Add(this.labelCPUFan);
@@ -592,6 +607,7 @@
         private PictureBox picturePerf;
         private Label labelPerf;
         private CheckBox checkGPU;
+        private CheckBox checkCPU;
         private Button buttonQuit;
         private PictureBox pictureScreen;
         private Label labelSreen;

--- a/Settings.cs
+++ b/Settings.cs
@@ -378,6 +378,17 @@ namespace GHelper
 
         }
 
+        public void AutoCPUMode(int Plugged = 1)
+        {
+            int CpuAuto = Program.config.getConfig("cpu_auto");
+            if(CpuAuto != 1) return;
+
+            if (Plugged == 1)
+                SetPerformanceMode(ASUSWmi.PerformanceBalanced);
+            else
+                SetPerformanceMode(ASUSWmi.PerformanceSilent);
+        }
+
         public void AutoGPUMode(int Plugged = 1)
         {
 
@@ -503,6 +514,11 @@ namespace GHelper
             checkGPU.Checked = (GPUAuto == 1);
         }
 
+        public void VisualiseCPUAuto(int CPUAuto)
+        {
+            checkCPU.Checked = (CPUAuto == 1);
+        }
+
         public void VisualiseScreenAuto(int ScreenAuto)
         {
             checkScreen.Checked = (ScreenAuto == 1);
@@ -621,8 +637,14 @@ namespace GHelper
             else
                 Program.config.setConfig("screen_auto", 0);
         }
-
-
+        private void checkCPU_CheckedChanged(object sender, EventArgs e)
+        {
+            CheckBox chk = (CheckBox)sender;
+            if (chk.Checked)
+                Program.config.setConfig("cpu_auto", 1);
+            else
+                Program.config.setConfig("cpu_auto", 0);
+        }
     }
 
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -3,6 +3,8 @@ using System.Diagnostics;
 using System.Management;
 using System.Timers;
 using System.Windows.Forms;
+using Windows.UI.Notifications;
+using Microsoft.Toolkit.Uwp.Notifications;
 
 namespace GHelper
 {
@@ -331,6 +333,12 @@ namespace GHelper
             buttonBalanced.FlatAppearance.BorderSize = buttonInactive;
             buttonTurbo.FlatAppearance.BorderSize = buttonInactive;
 
+            string[] mode = new string[]{
+                "Balanced",
+                "Turbo",
+                "Silent"
+            };
+
             switch (PerformanceMode)
             {
                 case ASUSWmi.PerformanceSilent:
@@ -348,11 +356,17 @@ namespace GHelper
                     break;
             }
 
+            labelPerf.Text = "Performance Mode: " + mode[PerformanceMode];
+
+            string notifTitle = "Performance Mode Changed";
+            string notifBody = "Switched to: " + mode[PerformanceMode];
 
             Program.config.setConfig("performance_mode", PerformanceMode);
             try
             {
                 Program.wmi.DeviceSet(ASUSWmi.PerformanceMode, PerformanceMode);
+                if(notify)
+                    sendNotification(notifTitle, notifBody);
             } catch
             {
                 labelPerf.Text = "Performance Mode: not supported";
@@ -363,8 +377,25 @@ namespace GHelper
 
         public void CyclePerformanceMode()
         {
-            SetPerformanceMode(Program.config.getConfig("performance_mode") + 1);
+            SetPerformanceMode(Program.config.getConfig("performance_mode") + 1, true);
         }
+
+
+        public void sendNotification(string title, string message)
+        {
+            var content = new ToastContentBuilder()
+                .AddText(title)
+                .AddText(message)
+                .GetToastContent();
+
+            var notification = new ToastNotification(content.GetXml())
+            {
+                Priority = ToastNotificationPriority.High
+            };
+
+            ToastNotificationManagerCompat.CreateToastNotifier().Show(notification);
+        }
+
 
         public void AutoScreen(int Plugged = 1)
         {
@@ -384,9 +415,9 @@ namespace GHelper
             if(CpuAuto != 1) return;
 
             if (Plugged == 1)
-                SetPerformanceMode(ASUSWmi.PerformanceBalanced);
+                SetPerformanceMode(ASUSWmi.PerformanceBalanced, true);
             else
-                SetPerformanceMode(ASUSWmi.PerformanceSilent);
+                SetPerformanceMode(ASUSWmi.PerformanceSilent, true);
         }
 
         public void AutoGPUMode(int Plugged = 1)


### PR DESCRIPTION
I thought that a good addition to the other options would be to automatically switch to silent mode when running on battery, since this could have a positive impact on battery life. Something that can be improved is the placement of the checkbox, since I couldn't get it working without breaking the other objects around.
![Screenshot 2023-02-20 234630](https://user-images.githubusercontent.com/79106176/220204228-fbceda40-cd00-4f5f-96b3-ca3a6d41ee4c.png)
 