### PR TITLE
 restart the computer without displaying the cmd

### DIFF
--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -1138,7 +1138,11 @@ namespace GHelper
             if (restart)
             {
                 VisualiseGPUMode();
-                Process.Start("shutdown", "/r /t 1");
+                ProcessStartInfo psi = new ProcessStartInfo("shutdown.exe", "/r /t 1");
+                psi.CreateNoWindow = true;
+                psi.UseShellExecute = false;
+
+                Process.Start(psi);
             }
 
         }


### PR DESCRIPTION
Restart the computer after a 1 second delay, without displaying the command prompt window.