### PR TITLE
Prevent 'ImageAnimator' from creating an unnecessary thread

### DIFF
--- a/app/Fans.Designer.cs
+++ b/app/Fans.Designer.cs
@@ -398,7 +398,7 @@ namespace GHelper
             // 
             pictureFine.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
             pictureFine.BackgroundImageLayout = ImageLayout.Zoom;
-            pictureFine.Image = Properties.Resources.everything_is_fine_itsfine;
+            pictureFine.Image = new Bitmap(Properties.Resources.everything_is_fine_itsfine);
             pictureFine.Location = new Point(20, 682);
             pictureFine.Margin = new Padding(4, 2, 4, 2);
             pictureFine.Name = "pictureFine";


### PR DESCRIPTION
Load .gif as an Image to prevent 'ImageAnimator' from creating an animation thread that basically is never used.

**Ideally, it would be best to get rid of that .gif entirely.**