### PR TITLE
Spanish translation fix for v0.55

### DIFF
--- a/app/Properties/Strings.es.resx
+++ b/app/Properties/Strings.es.resx
@@ -136,7 +136,7 @@
     <value>¿Reiniciar ahora?</value>
   </data>
   <data name="AnimationSpeed" xml:space="preserve">
-    <value>Velocidad de animación</value>
+    <value>Velocidad</value>
   </data>
   <data name="AnimeMatrix" xml:space="preserve">
     <value>Anime Matrix</value>


### PR DESCRIPTION
In v0.55 the new keyboard brightness bar cuts the Spanish translation. On the good side, this keyboard brightness bar works for controlling the keyboard brightness of my model! (GA401IV aka G14 2020)

![imagen](https://user-images.githubusercontent.com/62946623/233639694-7ae4e1d2-1c3d-4495-9ef1-b41d9205fd82.png)
