### PR TITLE
Add GitHub workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          7.0.x
+    - name: Build
+      run: |
+        dotnet build app/GHelper.sln

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,28 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+  - cron: '34 18 * * 3'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  codeql:
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v3
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: c#
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+    - name: Analyze
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  release:
+    types: [ published ]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: |
+          7.0.x
+    - name: Publish
+      run: |
+        dotnet publish app/GHelper.sln --configuration Release --runtime win-x64 -p:PublishSingleFile=true --no-self-contained
+        powershell Compress-Archive app/bin/x64/Release/net7.0-windows8.0/win-x64/publish/GHelper.exe GHelper.zip
+    - name: Upload
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh release upload ${{ github.ref_name }} app/bin/x64/Release/net7.0-windows8.0/win-x64/publish/GHelper.exe GHelper.zip


### PR DESCRIPTION
Adds GitHub workflows for automatic building, security scans, and release uploading.

- Build: runs the `dotnet build` command for merge requests and the `main` branch; useful for ensuring changes to source did not break the project.
- CodeQL: automates https://codeql.github.com/ and uploads any findings to the `Security` tab of the project (by default only accessible to developers)
- Release: automates `dotnet publish` and uploads the created executable to the new release. Just create the release as normal and the workflow will be started automagically. After it has run, the file will appear in the files section of the release.
  - I added the uncompressed `.exe` to the release files to provide users with flexibility with how they want to download the software
  - An example of a fully automated release can be found [here](https://github.com/tbateson/g-helper/releases/tag/test-release)