### PR TITLE
Windows power plan changes optional

### DIFF
--- a/app/AppConfig.cs
+++ b/app/AppConfig.cs
@@ -69,7 +69,6 @@ public class AppConfig
     {
         config = new Dictionary<string, object>();
         config["performance_mode"] = 0;
-        config["auto_apply_power_plan"] = 1;
         string jsonString = JsonSerializer.Serialize(config);
         File.WriteAllText(configFile, jsonString);
     }

--- a/app/AppConfig.cs
+++ b/app/AppConfig.cs
@@ -69,6 +69,7 @@ public class AppConfig
     {
         config = new Dictionary<string, object>();
         config["performance_mode"] = 0;
+        config["auto_apply_power_plan"] = 1;
         string jsonString = JsonSerializer.Serialize(config);
         File.WriteAllText(configFile, jsonString);
     }

--- a/app/Extra.Designer.cs
+++ b/app/Extra.Designer.cs
@@ -74,7 +74,7 @@ namespace GHelper
             checkSleepLid = new CheckBox();
             checkShutdownLid = new CheckBox();
             groupOther = new GroupBox();
-            checkApplyWindowsPowerMode = new CheckBox();
+            checkAutoApplyWindowsPowerMode = new CheckBox();
             checkKeyboardAuto = new CheckBox();
             checkUSBC = new CheckBox();
             checkNoOverdrive = new CheckBox();
@@ -575,12 +575,13 @@ namespace GHelper
             // 
             // groupOther
             // 
+            groupOther.Controls.Add(checkAutoApplyWindowsPowerMode);
             groupOther.Controls.Add(checkKeyboardAuto);
             groupOther.Controls.Add(checkUSBC);
             groupOther.Controls.Add(checkNoOverdrive);
             groupOther.Controls.Add(checkTopmost);
             groupOther.Dock = DockStyle.Top;
-            groupOther.Location = new Point(10, 768);
+            groupOther.Location = new Point(5, 358);
             groupOther.Name = "groupOther";
             groupOther.Size = new Size(954, 276);
             groupOther.TabIndex = 2;
@@ -590,8 +591,8 @@ namespace GHelper
             // checkKeyboardAuto
             // 
             checkKeyboardAuto.AutoSize = true;
-            checkKeyboardAuto.Location = new Point(25, 53);
             checkKeyboardAuto.MaximumSize = new Size(780, 0);
+            checkKeyboardAuto.Location = new Point(25, 40);
             checkKeyboardAuto.Name = "checkKeyboardAuto";
             checkKeyboardAuto.Size = new Size(712, 36);
             checkKeyboardAuto.TabIndex = 46;
@@ -601,7 +602,7 @@ namespace GHelper
             // checkUSBC
             // 
             checkUSBC.AutoSize = true;
-            checkUSBC.Location = new Point(25, 210);
+            checkUSBC.Location = new Point(25, 85);
             checkUSBC.Name = "checkUSBC";
             checkUSBC.Size = new Size(659, 36);
             checkUSBC.TabIndex = 4;
@@ -611,7 +612,7 @@ namespace GHelper
             // checkNoOverdrive
             // 
             checkNoOverdrive.AutoSize = true;
-            checkNoOverdrive.Location = new Point(25, 156);
+            checkNoOverdrive.Location = new Point(25, 130);
             checkNoOverdrive.Name = "checkNoOverdrive";
             checkNoOverdrive.Size = new Size(307, 36);
             checkNoOverdrive.TabIndex = 3;
@@ -621,12 +622,22 @@ namespace GHelper
             // checkTopmost
             // 
             checkTopmost.AutoSize = true;
-            checkTopmost.Location = new Point(25, 104);
+            checkTopmost.Location = new Point(25, 175);
             checkTopmost.Name = "checkTopmost";
             checkTopmost.Size = new Size(390, 36);
             checkTopmost.TabIndex = 1;
             checkTopmost.Text = Strings.WindowTop;
             checkTopmost.UseVisualStyleBackColor = true;
+            // 
+            // checkAutoApplyWindowsPowerMode
+            // 
+            checkAutoApplyWindowsPowerMode.AutoSize = true;
+            checkAutoApplyWindowsPowerMode.Location = new Point(25, 220);
+            checkAutoApplyWindowsPowerMode.Name = "checkAutoApplyWindowsPowerMode";
+            checkAutoApplyWindowsPowerMode.Size = new Size(211, 19);
+            checkAutoApplyWindowsPowerMode.TabIndex = 47;
+            checkAutoApplyWindowsPowerMode.Text = "Auto Adjust Windows Power Mode";
+            checkAutoApplyWindowsPowerMode.UseVisualStyleBackColor = true;
             // 
             // Extra
             // 
@@ -715,5 +726,6 @@ namespace GHelper
         private Label labelBacklightTimeout;
         private NumericUpDown numericBacklightTime;
         private CheckBox checkKeyboardAuto;
+        private CheckBox checkAutoApplyWindowsPowerMode;
     }
 }

--- a/app/Extra.Designer.cs
+++ b/app/Extra.Designer.cs
@@ -74,6 +74,7 @@ namespace GHelper
             checkSleepLid = new CheckBox();
             checkShutdownLid = new CheckBox();
             groupOther = new GroupBox();
+            checkApplyWindowsPowerMode = new CheckBox();
             checkKeyboardAuto = new CheckBox();
             checkUSBC = new CheckBox();
             checkNoOverdrive = new CheckBox();

--- a/app/Extra.cs
+++ b/app/Extra.cs
@@ -73,6 +73,7 @@ namespace GHelper
             checkNoOverdrive.Text = Properties.Strings.DisableOverdrive;
             checkTopmost.Text = Properties.Strings.WindowTop;
             checkUSBC.Text = Properties.Strings.OptimizedUSBC;
+            checkApplyWindowsPowerMode.Text = Properties.Strings.ApplyWindowsPowerPlan;
 
             labelBacklight.Text = Properties.Strings.Keyboard;
             labelBacklightBar.Text = Properties.Strings.Lightbar;
@@ -175,6 +176,8 @@ namespace GHelper
 
             checkUSBC.Checked = (Program.config.getConfig("optimized_usbc") == 1);
             checkUSBC.CheckedChanged += CheckUSBC_CheckedChanged;
+
+            checkApplyWindowsPowerMode.Checked = Program.config.getConfig("auto_apply_power_plan") == 1;
 
             int kb_brightness = Program.config.getConfig("keyboard_brightness");
             trackBrightness.Value = (kb_brightness >= 0 && kb_brightness <= 3) ? kb_brightness : 3;
@@ -298,6 +301,12 @@ namespace GHelper
         {
             Top = Program.settingsForm.Top;
             Left = Program.settingsForm.Left - Width - 5;
+        }
+
+        private void checkApplyWindowsPowerMode_CheckedChanged(object sender, EventArgs e)
+        {
+            CheckBox chk = (CheckBox)sender;
+            Program.config.setConfig("auto_apply_power_plan", chk.Checked ? 1 : 0);
         }
     }
 }

--- a/app/Extra.cs
+++ b/app/Extra.cs
@@ -304,7 +304,7 @@ namespace GHelper
             Left = Program.settingsForm.Left - Width - 5;
         }
 
-        private void checkAutoApplyWindowsPowerMode_CheckedChanged(object sender, EventArgs e)
+        private void checkAutoApplyWindowsPowerMode_CheckedChanged(object? sender, EventArgs e)
         {
             CheckBox chk = (CheckBox)sender;
             Program.config.setConfig("auto_apply_power_plan", chk.Checked ? 1 : 0);

--- a/app/Extra.cs
+++ b/app/Extra.cs
@@ -73,7 +73,7 @@ namespace GHelper
             checkNoOverdrive.Text = Properties.Strings.DisableOverdrive;
             checkTopmost.Text = Properties.Strings.WindowTop;
             checkUSBC.Text = Properties.Strings.OptimizedUSBC;
-            checkApplyWindowsPowerMode.Text = Properties.Strings.ApplyWindowsPowerPlan;
+            checkAutoApplyWindowsPowerMode.Text = Properties.Strings.ApplyWindowsPowerPlan;
 
             labelBacklight.Text = Properties.Strings.Keyboard;
             labelBacklightBar.Text = Properties.Strings.Lightbar;
@@ -177,7 +177,8 @@ namespace GHelper
             checkUSBC.Checked = (Program.config.getConfig("optimized_usbc") == 1);
             checkUSBC.CheckedChanged += CheckUSBC_CheckedChanged;
 
-            checkApplyWindowsPowerMode.Checked = Program.config.getConfig("auto_apply_power_plan") == 1;
+            checkAutoApplyWindowsPowerMode.Checked = Program.config.getConfig("auto_apply_power_plan") == 1;
+            checkAutoApplyWindowsPowerMode.CheckedChanged += checkAutoApplyWindowsPowerMode_CheckedChanged;
 
             int kb_brightness = Program.config.getConfig("keyboard_brightness");
             trackBrightness.Value = (kb_brightness >= 0 && kb_brightness <= 3) ? kb_brightness : 3;
@@ -303,7 +304,7 @@ namespace GHelper
             Left = Program.settingsForm.Left - Width - 5;
         }
 
-        private void checkApplyWindowsPowerMode_CheckedChanged(object sender, EventArgs e)
+        private void checkAutoApplyWindowsPowerMode_CheckedChanged(object sender, EventArgs e)
         {
             CheckBox chk = (CheckBox)sender;
             Program.config.setConfig("auto_apply_power_plan", chk.Checked ? 1 : 0);

--- a/app/Extra.cs
+++ b/app/Extra.cs
@@ -306,8 +306,7 @@ namespace GHelper
 
         private void checkAutoApplyWindowsPowerMode_CheckedChanged(object? sender, EventArgs e)
         {
-            CheckBox chk = (CheckBox)sender;
-            Program.config.setConfig("auto_apply_power_plan", chk.Checked ? 1 : 0);
+            Program.config.setConfig("auto_apply_power_plan", checkAutoApplyWindowsPowerMode.Checked ? 1 : 0);
         }
     }
 }

--- a/app/Properties/Strings.Designer.cs
+++ b/app/Properties/Strings.Designer.cs
@@ -169,7 +169,16 @@ namespace GHelper.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Breathe.
+        ///   Looks up a localized string similar to Auto Adjust Windows Power Plan.
+        /// </summary>
+        internal static string ApplyWindowsPowerPlan {
+            get {
+                return ResourceManager.GetString("ApplyWindowsPowerPlan", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///  Looks up a localized string similar to Breathe.
         /// </summary>
         internal static string AuraBreathe {
             get {

--- a/app/Properties/Strings.de.resx
+++ b/app/Properties/Strings.de.resx
@@ -94,6 +94,9 @@
   <data name="ApplyPowerLimits" xml:space="preserve">
     <value>Apply Power Limits</value>
   </data>
+  <data name="ApplyWindowsPowerPlan" xml:space="preserve">
+    <value>Auto Adjust Windows Power Plan</value>
+  </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>Breathe</value>
   </data>

--- a/app/Properties/Strings.de.resx
+++ b/app/Properties/Strings.de.resx
@@ -95,7 +95,7 @@
     <value>Apply Power Limits</value>
   </data>
   <data name="ApplyWindowsPowerPlan" xml:space="preserve">
-    <value>Auto Adjust Windows Power Plan</value>
+    <value>Auto Adjust Windows Power Mode</value>
   </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>Breathe</value>

--- a/app/Properties/Strings.es.resx
+++ b/app/Properties/Strings.es.resx
@@ -153,6 +153,9 @@
   <data name="ApplyPowerLimits" xml:space="preserve">
     <value>Aplicar límites de energía</value>
   </data>
+  <data name="ApplyWindowsPowerPlan" xml:space="preserve">
+    <value>Auto Adjust Windows Power Plan</value>
+  </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>Respiración</value>
   </data>

--- a/app/Properties/Strings.es.resx
+++ b/app/Properties/Strings.es.resx
@@ -154,7 +154,7 @@
     <value>Aplicar límites de energía</value>
   </data>
   <data name="ApplyWindowsPowerPlan" xml:space="preserve">
-    <value>Auto Adjust Windows Power Plan</value>
+    <value>Auto Adjust Windows Power Mode</value>
   </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>Respiración</value>

--- a/app/Properties/Strings.fr.resx
+++ b/app/Properties/Strings.fr.resx
@@ -94,6 +94,9 @@
   <data name="ApplyPowerLimits" xml:space="preserve">
     <value>Apply Power Limits</value>
   </data>
+  <data name="ApplyWindowsPowerPlan" xml:space="preserve">
+    <value>Auto Adjust Windows Power Plan</value>
+  </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>Breathe</value>
   </data>
@@ -300,9 +303,6 @@
   </data>
   <data name="RunOnStartup" xml:space="preserve">
     <value>Run on Startup</value>
-  </data>
-  <data name="SApplyWindowsPowerPlan" xml:space="preserve">
-    <value>Auto Adjust Windows Power Plan</value>
   </data>
   <data name="Shutdown" xml:space="preserve">
     <value>Shutdown</value>

--- a/app/Properties/Strings.fr.resx
+++ b/app/Properties/Strings.fr.resx
@@ -301,6 +301,9 @@
   <data name="RunOnStartup" xml:space="preserve">
     <value>Run on Startup</value>
   </data>
+  <data name="SApplyWindowsPowerPlan" xml:space="preserve">
+    <value>Auto Adjust Windows Power Plan</value>
+  </data>
   <data name="Shutdown" xml:space="preserve">
     <value>Shutdown</value>
   </data>

--- a/app/Properties/Strings.fr.resx
+++ b/app/Properties/Strings.fr.resx
@@ -95,7 +95,7 @@
     <value>Apply Power Limits</value>
   </data>
   <data name="ApplyWindowsPowerPlan" xml:space="preserve">
-    <value>Auto Adjust Windows Power Plan</value>
+    <value>Auto Adjust Windows Power Mode</value>
   </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>Breathe</value>

--- a/app/Properties/Strings.it.resx
+++ b/app/Properties/Strings.it.resx
@@ -94,6 +94,9 @@
   <data name="ApplyPowerLimits" xml:space="preserve">
     <value>Apply Power Limits</value>
   </data>
+  <data name="ApplyWindowsPowerPlan" xml:space="preserve">
+    <value>Auto Adjust Windows Power Plan</value>
+  </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>Breathe</value>
   </data>

--- a/app/Properties/Strings.it.resx
+++ b/app/Properties/Strings.it.resx
@@ -95,7 +95,7 @@
     <value>Apply Power Limits</value>
   </data>
   <data name="ApplyWindowsPowerPlan" xml:space="preserve">
-    <value>Auto Adjust Windows Power Plan</value>
+    <value>Auto Adjust Windows Power Mode</value>
   </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>Breathe</value>

--- a/app/Properties/Strings.resx
+++ b/app/Properties/Strings.resx
@@ -153,6 +153,9 @@
   <data name="ApplyPowerLimits" xml:space="preserve">
     <value>Apply Power Limits</value>
   </data>
+  <data name="ApplyWindowsPowerPlan" xml:space="preserve">
+    <value>Auto Adjust Windows Power Plan</value>
+  </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>Breathe</value>
   </data>

--- a/app/Properties/Strings.tr.resx
+++ b/app/Properties/Strings.tr.resx
@@ -153,6 +153,9 @@
   <data name="ApplyPowerLimits" xml:space="preserve">
     <value>Güç Sınırlarını Uygula</value>
   </data>
+  <data name="ApplyWindowsPowerPlan" xml:space="preserve">
+    <value>Auto Adjust Windows Power Plan</value>
+  </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>Nefes</value>
   </data>

--- a/app/Properties/Strings.tr.resx
+++ b/app/Properties/Strings.tr.resx
@@ -154,7 +154,7 @@
     <value>Güç Sınırlarını Uygula</value>
   </data>
   <data name="ApplyWindowsPowerPlan" xml:space="preserve">
-    <value>Auto Adjust Windows Power Plan</value>
+    <value>Auto Adjust Windows Power Mode</value>
   </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>Nefes</value>

--- a/app/Properties/Strings.uk.resx
+++ b/app/Properties/Strings.uk.resx
@@ -154,7 +154,7 @@
     <value>Застосувати потужність</value>
   </data>
   <data name="ApplyWindowsPowerPlan" xml:space="preserve">
-    <value>Auto Adjust Windows Power Plan</value>
+    <value>Auto Adjust Windows Power Mode</value>
   </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>Дихання</value>

--- a/app/Properties/Strings.uk.resx
+++ b/app/Properties/Strings.uk.resx
@@ -153,6 +153,9 @@
   <data name="ApplyPowerLimits" xml:space="preserve">
     <value>Застосувати потужність</value>
   </data>
+  <data name="ApplyWindowsPowerPlan" xml:space="preserve">
+    <value>Auto Adjust Windows Power Plan</value>
+  </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>Дихання</value>
   </data>

--- a/app/Properties/Strings.zh-CN.resx
+++ b/app/Properties/Strings.zh-CN.resx
@@ -153,6 +153,9 @@
   <data name="ApplyPowerLimits" xml:space="preserve">
     <value>应用功率限制</value>
   </data>
+  <data name="ApplyWindowsPowerPlan" xml:space="preserve">
+    <value>Auto Adjust Windows Power Plan</value>
+  </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>呼吸</value>
   </data>

--- a/app/Properties/Strings.zh-CN.resx
+++ b/app/Properties/Strings.zh-CN.resx
@@ -154,7 +154,7 @@
     <value>应用功率限制</value>
   </data>
   <data name="ApplyWindowsPowerPlan" xml:space="preserve">
-    <value>Auto Adjust Windows Power Plan</value>
+    <value>Auto Adjust Windows Power Mode</value>
   </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>呼吸</value>

--- a/app/Properties/Strings.zh-TW.resx
+++ b/app/Properties/Strings.zh-TW.resx
@@ -154,7 +154,7 @@
     <value>套用功率限制</value>
   </data>
   <data name="ApplyWindowsPowerPlan" xml:space="preserve">
-    <value>Auto Adjust Windows Power Plan</value>
+    <value>Auto Adjust Windows Power Mode</value>
   </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>呼吸</value>

--- a/app/Properties/Strings.zh-TW.resx
+++ b/app/Properties/Strings.zh-TW.resx
@@ -153,6 +153,9 @@
   <data name="ApplyPowerLimits" xml:space="preserve">
     <value>套用功率限制</value>
   </data>
+  <data name="ApplyWindowsPowerPlan" xml:space="preserve">
+    <value>Auto Adjust Windows Power Plan</value>
+  </data>
   <data name="AuraBreathe" xml:space="preserve">
     <value>呼吸</value>
   </data>

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -1286,7 +1286,7 @@ namespace GHelper
             AutoFans();
             AutoPower(1000);
 
-            if (Program.config.getConfigPerf("auto_apply_power_plan") == 1)
+            if (Program.config.getConfigPerf("auto_apply_power_plan") != 0)
             {
                 if (Program.config.getConfigPerfString("scheme") is not null)
                     NativeMethods.SetPowerScheme(Program.config.getConfigPerfString("scheme"));

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -1286,7 +1286,7 @@ namespace GHelper
             AutoFans();
             AutoPower(1000);
 
-            if (Program.config.getConfigPerf("auto_apply_power_plan") != 0)
+            if (Program.config.getConfig("auto_apply_power_plan") != 0)
             {
                 if (Program.config.getConfigPerfString("scheme") is not null)
                     NativeMethods.SetPowerScheme(Program.config.getConfigPerfString("scheme"));

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -1286,11 +1286,13 @@ namespace GHelper
             AutoFans();
             AutoPower(1000);
 
-
-            if (Program.config.getConfigPerfString("scheme") is not null)
-                NativeMethods.SetPowerScheme(Program.config.getConfigPerfString("scheme"));
-            else
-                NativeMethods.SetPowerScheme(PerformanceMode);
+            if (Program.config.getConfigPerf("auto_apply_power_plan") == 1)
+            {
+                if (Program.config.getConfigPerfString("scheme") is not null)
+                    NativeMethods.SetPowerScheme(Program.config.getConfigPerfString("scheme"));
+                else
+                    NativeMethods.SetPowerScheme(PerformanceMode);
+            }
 
             if (Program.config.getConfigPerf("auto_boost") != -1)
             {


### PR DESCRIPTION
Fixed the incomplete PR [https://github.com/seerge/g-helper/pull/385 ](https://github.com/seerge/g-helper/pull/385 )

Right now, GHelper automatically adjusts the Windows Power Scheme Overlay (Best Energy Saving, Balanced, Best Performance) when you switch performance mode.
I added a checkbox to make this change optional as it might not be desired. If you uncheck the box, GHelper does not modify the power scheme overlay anymore.

This only affects the change of power overlay. Other features, like change of boost behavior, are unaffected by this.

This setting is not per performance mode but global.