### PR TITLE
Ignore .idea folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
+# JetBrains Rider
+.idea/


### PR DESCRIPTION
JetBrains Rider leaves some internal files upon opening the project, we don't really need them in version control.

![image](https://i.imgur.com/wc5Kxbg.png)