### PR TITLE
Detect screen frequency if possible for OD buttons

### DIFF
--- a/app/NativeMethods.cs
+++ b/app/NativeMethods.cs
@@ -653,7 +653,7 @@ public class NativeMethods
 
             var screens = Screen.AllScreens;
 
-            if (screens.Length != count) return Screen.PrimaryScreen.DeviceName;
+            if (screens.Length != count) return null;
 
             count = 0;
             foreach (var screen in screens)
@@ -679,11 +679,10 @@ public class NativeMethods
         return laptopScreen;
     }
 
-    public static int GetRefreshRate(bool max = false)
+    public static int GetRefreshRate(string laptopScreen, bool max = false)
     {
         DEVMODE dm = CreateDevmode();
 
-        string laptopScreen = FindLaptopScreen();
         int frequency = -1;
 
         if (laptopScreen is null)

--- a/app/NativeMethods.cs
+++ b/app/NativeMethods.cs
@@ -653,7 +653,7 @@ public class NativeMethods
 
             var screens = Screen.AllScreens;
 
-            if (screens.Length != count) return null;
+            if (screens.Length != count) return Screen.PrimaryScreen.DeviceName;
 
             count = 0;
             foreach (var screen in screens)

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -875,6 +875,11 @@ namespace GHelper
 
             bool screenEnabled = (frequency >= 0);
 
+            // Default to 120Hz if unknown, usually happens if Mux is switched to dGPU-only.
+            // It's been observed that dGPU screen is named same as internal screen, but with EXTERNAL at the end. Might as well check for that?
+            var displayFrequency = maxFrequency > 0 ? maxFrequency : 120; 
+            button120Hz.Text = $"{displayFrequency} Hz + OD";
+            
             ButtonEnabled(button60Hz, screenEnabled);
             ButtonEnabled(button120Hz, screenEnabled);
             ButtonEnabled(buttonScreenAuto, screenEnabled);

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -828,8 +828,9 @@ namespace GHelper
 
         public void SetScreen(int frequency = -1, int overdrive = -1, int miniled = -1)
         {
-
-            if (NativeMethods.GetRefreshRate() < 0) // Laptop screen not detected or has unknown refresh rate
+            var laptopScreen = NativeMethods.FindLaptopScreen();
+            
+            if (NativeMethods.GetRefreshRate(laptopScreen) < 0) // Laptop screen not detected or has unknown refresh rate
             {
                 InitScreen();
                 return;
@@ -837,7 +838,7 @@ namespace GHelper
 
             if (frequency >= 1000)
             {
-                frequency = NativeMethods.GetRefreshRate(true);
+                frequency = NativeMethods.GetRefreshRate(laptopScreen, true);
             }
 
             if (frequency > 0)
@@ -863,9 +864,10 @@ namespace GHelper
 
         public void InitScreen()
         {
-
-            int frequency = NativeMethods.GetRefreshRate();
-            int maxFrequency = NativeMethods.GetRefreshRate(true);
+            var laptopScreen = NativeMethods.FindLaptopScreen();
+            
+            int frequency = NativeMethods.GetRefreshRate(laptopScreen);
+            int maxFrequency = NativeMethods.GetRefreshRate(laptopScreen, true);
 
             bool screenAuto = (AppConfig.Get("screen_auto") == 1);
             bool overdriveSetting = (AppConfig.Get("no_overdrive") != 1);
@@ -875,9 +877,7 @@ namespace GHelper
 
             bool screenEnabled = (frequency >= 0);
 
-            // Default to 120Hz if unknown, usually happens if Mux is switched to dGPU-only.
-            // It's been observed that dGPU screen is named same as internal screen, but with EXTERNAL at the end. Might as well check for that?
-            var displayFrequency = maxFrequency > 0 ? maxFrequency : 120; 
+            var displayFrequency = maxFrequency > 0 ? maxFrequency : NativeMethods.GetRefreshRate(Screen.PrimaryScreen.DeviceName); 
             button120Hz.Text = $"{displayFrequency} Hz + OD";
             
             ButtonEnabled(button60Hz, screenEnabled);


### PR DESCRIPTION
Currently it says 120HZ no matter what display one may have. We need a stable way of detecting true screen refresh rate.

One problem remains is that if the laptop has Mux Switch, and it has been set to dGPU-only mode, we cannot detect laptop screen properly as it's detected as external.

I have observed that the screen name is exactly the same as the internal screen name, but with the EXTERNAL tag at the end of the name string. Can we somehow use external-but-internal screen if primary screen is not detected perhaps?