### PR TITLE
Fixed: Keyboard color cannot be set to white anymore

### DIFF
--- a/app/AsusUSB.cs
+++ b/app/AsusUSB.cs
@@ -175,14 +175,12 @@ namespace GHelper
 
         public static void SetColor(int colorCode)
         {
-            if (colorCode == -1) Color1 = Color.Red;
-            else Color1 = Color.FromArgb(colorCode);
+            Color1 = Color.FromArgb(colorCode);
         }
 
         public static void SetColor2(int colorCode)
         {
-            if (colorCode == -1) Color2 = Color.White;
-            else Color2 = Color.FromArgb(colorCode);
+            Color2 = Color.FromArgb(colorCode);
         }
 
 


### PR DESCRIPTION
I just found out that with the latest pre-release (0.99.0.0), I cannot set my keyboard backlight color to white anymore. It always reverts to red. Every other color works fine.
After some debugging, I found out that white is encoded as "-1" by ToARGB().
This code was added by a recent commit, but it has the side effect of preventing white color. I'm not sure what this check is about, but -1 is not an invalid value, but pure white color (255/255/255).