### PR TITLE
Prevent the Nvidia Advanced Optimimus "fake" display to be considered an external display.

### DIFF
--- a/app/Helpers/ClamshellModeControl.cs
+++ b/app/Helpers/ClamshellModeControl.cs
@@ -10,10 +10,13 @@ namespace GHelper.Helpers
         {
             var devices = ScreenInterrogatory.GetAllDevices().ToArray();
 
+            string internalName = AppConfig.GetString("internal_display");
+
             foreach (var device in devices)
             {
                 if (device.outputTechnology != ScreenInterrogatory.DISPLAYCONFIG_VIDEO_OUTPUT_TECHNOLOGY.DISPLAYCONFIG_OUTPUT_TECHNOLOGY_INTERNAL &&
-                    device.outputTechnology != ScreenInterrogatory.DISPLAYCONFIG_VIDEO_OUTPUT_TECHNOLOGY.DISPLAYCONFIG_OUTPUT_TECHNOLOGY_DISPLAYPORT_EMBEDDED)
+                    device.outputTechnology != ScreenInterrogatory.DISPLAYCONFIG_VIDEO_OUTPUT_TECHNOLOGY.DISPLAYCONFIG_OUTPUT_TECHNOLOGY_DISPLAYPORT_EMBEDDED
+                    && device.monitorFriendlyDeviceName != internalName)
                 {
                     Logger.WriteLine("Found external screen: " + device.monitorFriendlyDeviceName + ":" + device.outputTechnology.ToString());
 


### PR DESCRIPTION
This should prevent the fake display, that Nvidia Advanced Optimus creates, to confuse the clamshell detection.