### PR TITLE
USB packet logger only for debug builds or if enabled in config

### DIFF
--- a/app/Peripherals/Mouse/AsusMouse.cs
+++ b/app/Peripherals/Mouse/AsusMouse.cs
@@ -206,6 +206,16 @@ namespace GHelper.Peripherals.Mouse
             }
         }
 
+        private static bool IsPacketLoggerEnabled()
+        {
+#if DEBUG
+            return true;
+#else
+
+            return AppConfig.Get("usb_packet_logger") == 1;
+#endif
+        }
+
         [MethodImpl(MethodImplOptions.Synchronized)]
         protected virtual byte[]? WriteForResponse(byte[] packet)
         {
@@ -213,11 +223,15 @@ namespace GHelper.Peripherals.Mouse
 
             try
             {
-                Logger.WriteLine(GetDisplayName() + ": Sending packet: " + ByteArrayToString(packet));
+                if (IsPacketLoggerEnabled())
+                    Logger.WriteLine(GetDisplayName() + ": Sending packet: " + ByteArrayToString(packet));
+
                 Write(packet);
 
                 Read(response);
-                Logger.WriteLine(GetDisplayName() + ": Read packet: " + ByteArrayToString(response));
+
+                if (IsPacketLoggerEnabled())
+                    Logger.WriteLine(GetDisplayName() + ": Read packet: " + ByteArrayToString(response));
             }
             catch (IOException e)
             {

--- a/app/Peripherals/PeripheralsProvider.cs
+++ b/app/Peripherals/PeripheralsProvider.cs
@@ -145,7 +145,7 @@ namespace GHelper.Peripherals
         {
             if (am.IsDeviceConnected() && !ConnectedMice.Contains(am))
             {
-                Logger.WriteLine("Detected a new ROG Chakram X. Connecting...");
+                Logger.WriteLine("Detected a new" + am.GetDisplayName() + " . Connecting...");
                 Connect(am);
             }
         }


### PR DESCRIPTION
I disabled the USB packet logger by default as it is not necessary for normal operation. 
It is still enabled for Debug builds or if  `usb_packet_logger` is set to 1 in app config.

Also fixed the hardcoded logging name in the peripheral detection that stayed in there for some reason.