### PR TITLE
Asus mouse fixes

### DIFF
--- a/app/AsusMouseSettings.cs
+++ b/app/AsusMouseSettings.cs
@@ -95,6 +95,10 @@ namespace GHelper
         {
             this.Invoke(delegate
             {
+                if (Disposing || IsDisposed)
+                {
+                    return;
+                }
                 VisualizeBatteryState();
             });
 
@@ -312,6 +316,10 @@ namespace GHelper
             //Mouse disconnected. Bye bye.
             this.Invoke(delegate
             {
+                if (Disposing || IsDisposed)
+                {
+                    return;
+                }
                 this.Close();
             });
 

--- a/app/AsusMouseSettings.cs
+++ b/app/AsusMouseSettings.cs
@@ -89,6 +89,22 @@ namespace GHelper
         {
             mouse.BatteryUpdated -= Mouse_BatteryUpdated;
             mouse.Disconnect -= Mouse_Disconnect;
+            mouse.MouseReadyChanged -= Mouse_MouseReadyChanged;
+        }
+
+        private void Mouse_MouseReadyChanged(object? sender, EventArgs e)
+        {
+            if (!mouse.IsDeviceReady)
+            {
+                this.Invoke(delegate
+                {
+                    if (Disposing || IsDisposed)
+                    {
+                        return;
+                    }
+                    Close();
+                });
+            }
         }
 
         private void Mouse_BatteryUpdated(object? sender, EventArgs e)
@@ -606,6 +622,10 @@ namespace GHelper
             for (int i = 0; i < mouse.DPIProfileCount() && i < 4; ++i)
             {
                 AsusMouseDPI dpi = mouse.DpiSettings[i];
+                if (dpi is null)
+                {
+                    continue;
+                }
                 if (mouse.HasDPIColors())
                 {
                     dpiButtons[i].Image = ControlHelper.TintImage(Properties.Resources.lighting_dot_24, dpi.Color);
@@ -641,6 +661,7 @@ namespace GHelper
 
             mouse.Disconnect += Mouse_Disconnect;
             mouse.BatteryUpdated += Mouse_BatteryUpdated;
+            mouse.MouseReadyChanged += Mouse_MouseReadyChanged;
         }
 
         private void ButtonSync_Click(object sender, EventArgs e)

--- a/app/Peripherals/Mouse/AsusMouse.cs
+++ b/app/Peripherals/Mouse/AsusMouse.cs
@@ -400,7 +400,9 @@ namespace GHelper.Peripherals.Mouse
 
             if (HasLowBatteryWarning() || HasAutoPowerOff())
             {
-                Logger.WriteLine(GetDisplayName() + ": Got Auto Power Off: " + PowerOffSetting + " - Low Battery Warnning at: " + LowBatteryWarning + "%");
+                string pos = HasAutoPowerOff() ? PowerOffSetting.ToString() : "Not Supported";
+                string lbw = HasLowBatteryWarning() ? LowBatteryWarning.ToString() : "Not Supported";
+                Logger.WriteLine(GetDisplayName() + ": Got Auto Power Off: " + pos + " - Low Battery Warnning at: " + lbw + "%");
             }
 
         }

--- a/app/Peripherals/Mouse/AsusMouse.cs
+++ b/app/Peripherals/Mouse/AsusMouse.cs
@@ -688,6 +688,11 @@ namespace GHelper.Peripherals.Mouse
 
         protected virtual byte[] GetChangeDPIProfilePacket(int profile)
         {
+            return new byte[] { 0x00, 0x51, 0x31, 0x0A, 0x00, (byte)profile };
+        }
+
+        protected virtual byte[] GetChangeDPIProfilePacket2(int profile)
+        {
             return new byte[] { 0x00, 0x51, 0x31, 0x09, 0x00, (byte)profile };
         }
 
@@ -707,6 +712,8 @@ namespace GHelper.Peripherals.Mouse
 
             //The first DPI profile is 1
             WriteForResponse(GetChangeDPIProfilePacket(profile));
+            //For whatever reason that is required or the mouse will not store the change and reverts once you power it off.
+            WriteForResponse(GetChangeDPIProfilePacket2(profile));
             FlushSettings();
 
             Logger.WriteLine(GetDisplayName() + ": DPI Profile set to " + profile);

--- a/app/Peripherals/Mouse/AsusMouse.cs
+++ b/app/Peripherals/Mouse/AsusMouse.cs
@@ -161,6 +161,7 @@ namespace GHelper.Peripherals.Mouse
 
         public override void Dispose()
         {
+            Logger.WriteLine(GetDisplayName() + ": Disposing");
             HidSharp.DeviceList.Local.Changed -= Device_Changed;
             base.Dispose();
         }
@@ -200,6 +201,7 @@ namespace GHelper.Peripherals.Mouse
 
         protected virtual void OnDisconnect()
         {
+            Logger.WriteLine(GetDisplayName() + ": OnDisconnect()");
             if (Disconnect is not null)
             {
                 Disconnect(this, EventArgs.Empty);

--- a/app/Peripherals/Mouse/AsusMouse.cs
+++ b/app/Peripherals/Mouse/AsusMouse.cs
@@ -102,7 +102,7 @@ namespace GHelper.Peripherals.Mouse
     public abstract class AsusMouse : Device, IPeripheral
     {
         private static string[] POLLING_RATES = { "125 Hz", "250 Hz", "500 Hz", "1000 Hz", "2000 Hz", "4000 Hz", "8000 Hz", "16000 Hz" };
-
+        internal const bool PACKET_LOGGER_ALWAYS_ON = false;
         internal const int ASUS_MOUSE_PACKET_SIZE = 65;
 
         public event EventHandler? Disconnect;
@@ -212,7 +212,7 @@ namespace GHelper.Peripherals.Mouse
             return true;
 #else
 
-            return AppConfig.Get("usb_packet_logger") == 1;
+            return AppConfig.Get("usb_packet_logger") == 1 || PACKET_LOGGER_ALWAYS_ON;
 #endif
         }
 

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -1096,13 +1096,11 @@ namespace GHelper
                 {
                     b.Text = m.GetDisplayName() + "\n" + m.Battery + "%"
                     + (m.Charging ? "(" + Properties.Strings.Charging + ")" : "");
-                    b.Enabled = true;
                 }
                 else
                 {
                     //Mouse is either not connected or in standby
                     b.Text = m.GetDisplayName() + "\n(" + Properties.Strings.NotConnected + ")";
-                    b.Enabled = false;
                 }
 
                 switch (m.DeviceType())
@@ -1144,7 +1142,7 @@ namespace GHelper
             if (iph.DeviceType() == PeripheralType.Mouse)
             {
                 AsusMouse? am = iph as AsusMouse;
-                if (am is null)
+                if (am is null || !am.IsDeviceReady)
                 {
                     //Should not happen if all device classes are implemented correctly. But better safe than sorry.
                     return;


### PR DESCRIPTION
Some fixes for the mouse settings.

- Prevents crashes if the mouse disconnects when the window is open.
- DPI profile is now stored properly so it stays when the mouse is restarted.
- Mouse updates are handled in background to not lock up the UI when the mouse is slow to respond.