### PR TITLE
Clamshell power user settings

### DIFF
--- a/app/Helpers/ClamshellModeControl.cs
+++ b/app/Helpers/ClamshellModeControl.cs
@@ -6,6 +6,13 @@ namespace GHelper.Helpers
 {
     internal class ClamshellModeControl
     {
+
+        public ClamshellModeControl()
+        {
+            //Save current setting if hibernate or shutdown to prevent reverting the user set option.
+            CheckAndSaveLidAction();
+        }
+
         public bool IsExternalDisplayConnected()
         {
             var devices = ScreenInterrogatory.GetAllDevices().ToArray();
@@ -88,6 +95,21 @@ namespace GHelper.Helpers
 
             if (IsClamshellEnabled())
                 ToggleLidAction();
+        }
+
+        private static int CheckAndSaveLidAction()
+        {
+            int val = PowerNative.GetLidAction(true);
+            //If it is 0 then it is likely already set by clamshell mdoe
+            //If 0 was set by the user, then why do they even use clamshell mode?
+            //We only care about hibernate or shutdown setting here
+            if (val == 2 || val == 3)
+            {
+                AppConfig.Set("clamshell_default_lid_action", val);
+                return val;
+            }
+
+            return 1;
         }
 
         //Power users can change that setting.

--- a/app/Helpers/ClamshellModeControl.cs
+++ b/app/Helpers/ClamshellModeControl.cs
@@ -97,7 +97,14 @@ namespace GHelper.Helpers
         //3 = Shutdown
         private static int GetDefaultLidAction()
         {
-            return AppConfig.Get("clamshell_default_lid_action", 1);
+            int val = AppConfig.Get("clamshell_default_lid_action", 1);
+
+            if (val < 0 || val > 3)
+            {
+                val = 1;
+            }
+
+            return val;
         }
     }
 }

--- a/app/Helpers/ClamshellModeControl.cs
+++ b/app/Helpers/ClamshellModeControl.cs
@@ -62,7 +62,7 @@ namespace GHelper.Helpers
         }
         public static void DisableClamshellMode()
         {
-            PowerNative.SetLidAction(1, true);
+            PowerNative.SetLidAction(GetDefaultLidAction(), true);
             Logger.WriteLine("Disengaging Clamshell Mode");
         }
 
@@ -88,6 +88,16 @@ namespace GHelper.Helpers
 
             if (IsClamshellEnabled())
                 ToggleLidAction();
+        }
+
+        //Power users can change that setting.
+        //0 = Do nothing
+        //1 = Sleep (default)
+        //2 = Hibernate
+        //3 = Shutdown
+        private static int GetDefaultLidAction()
+        {
+            return AppConfig.Get("clamshell_default_lid_action", 1);
         }
     }
 }

--- a/app/Helpers/ClamshellModeControl.cs
+++ b/app/Helpers/ClamshellModeControl.cs
@@ -31,7 +31,7 @@ namespace GHelper.Helpers
 
         public bool IsClamshellEnabled()
         {
-            return AppConfig.Get("toggle_clamshell_mode") != 0;
+            return AppConfig.Is("toggle_clamshell_mode");
         }
 
         public bool IsChargerConnected()

--- a/app/Helpers/ClamshellModeControl.cs
+++ b/app/Helpers/ClamshellModeControl.cs
@@ -99,6 +99,12 @@ namespace GHelper.Helpers
 
         private static int CheckAndSaveLidAction()
         {
+            if (AppConfig.Get("clamshell_default_lid_action", -1) != -1)
+            {
+                //Seting was alredy set. Do not touch it
+                return AppConfig.Get("clamshell_default_lid_action", -1);
+            }
+
             int val = PowerNative.GetLidAction(true);
             //If it is 0 then it is likely already set by clamshell mdoe
             //If 0 was set by the user, then why do they even use clamshell mode?

--- a/app/Mode/PowerNative.cs
+++ b/app/Mode/PowerNative.cs
@@ -167,6 +167,28 @@ namespace GHelper.Mode
             }
         }
 
+        public static int GetLidAction(bool ac)
+        {
+            Guid activeSchemeGuid = GetActiveScheme();
+
+            IntPtr activeIndex;
+            if (ac)
+                PowerReadACValueIndex(IntPtr.Zero,
+                     activeSchemeGuid,
+                     GUID_SYSTEM_BUTTON_SUBGROUP,
+                     GUID_LIDACTION, out activeIndex);
+
+            else
+                PowerReadDCValueIndex(IntPtr.Zero,
+                    activeSchemeGuid,
+                    GUID_SYSTEM_BUTTON_SUBGROUP,
+                    GUID_LIDACTION, out activeIndex);
+
+
+            return activeIndex.ToInt32();
+        }
+
+
         public static void SetLidAction(int action, bool acOnly = false)
         {
             /**


### PR DESCRIPTION
This allows users to set their lid default action when clamshell is not engaged.

Set `clamshell_default_lid_action` in config.json to any of those values.

0 = Do nothing
1 = Sleep (default)
2 = Hibernate
3 = Shutdown