### PR TITLE
ASUS Mouse: Resolved deadlocks

### DIFF
--- a/app/AsusMouseSettings.cs
+++ b/app/AsusMouseSettings.cs
@@ -82,7 +82,7 @@ namespace GHelper
 
             InitMouseCapabilities();
             Logger.WriteLine(mouse.GetDisplayName() + " (GUI): Initialized capabilities. Synchronizing mouse data");
-            Task task = Task.Run((Action)RefreshMouseData);
+            RefreshMouseData();
         }
 
         private void AsusMouseSettings_FormClosing(object? sender, FormClosingEventArgs e)

--- a/app/AsusMouseSettings.cs
+++ b/app/AsusMouseSettings.cs
@@ -94,14 +94,14 @@ namespace GHelper
 
         private void Mouse_MouseReadyChanged(object? sender, EventArgs e)
         {
+            if (Disposing || IsDisposed)
+            {
+                return;
+            }
             if (!mouse.IsDeviceReady)
             {
                 this.Invoke(delegate
                 {
-                    if (Disposing || IsDisposed)
-                    {
-                        return;
-                    }
                     Close();
                 });
             }
@@ -109,12 +109,12 @@ namespace GHelper
 
         private void Mouse_BatteryUpdated(object? sender, EventArgs e)
         {
+            if (Disposing || IsDisposed)
+            {
+                return;
+            }
             this.Invoke(delegate
             {
-                if (Disposing || IsDisposed)
-                {
-                    return;
-                }
                 VisualizeBatteryState();
             });
 

--- a/app/Peripherals/PeripheralsProvider.cs
+++ b/app/Peripherals/PeripheralsProvider.cs
@@ -63,6 +63,9 @@ namespace GHelper.Peripherals
         {
             lock (_LOCK)
             {
+                am.Disconnect -= Mouse_Disconnect;
+                am.MouseReadyChanged -= MouseReadyChanged;
+                am.BatteryUpdated -= BatteryUpdated;
                 ConnectedMice.Remove(am);
             }
             if (DeviceChanged is not null)
@@ -110,10 +113,22 @@ namespace GHelper.Peripherals
 
 
             am.Disconnect += Mouse_Disconnect;
+            am.MouseReadyChanged += MouseReadyChanged;
+            am.BatteryUpdated += BatteryUpdated;
             if (DeviceChanged is not null)
             {
                 DeviceChanged(am, EventArgs.Empty);
             }
+            UpdateSettingsView();
+        }
+
+        private static void BatteryUpdated(object? sender, EventArgs e)
+        {
+            UpdateSettingsView();
+        }
+
+        private static void MouseReadyChanged(object? sender, EventArgs e)
+        {
             UpdateSettingsView();
         }
 

--- a/app/Peripherals/PeripheralsProvider.cs
+++ b/app/Peripherals/PeripheralsProvider.cs
@@ -1,5 +1,6 @@
 ﻿using GHelper.Peripherals.Mouse;
 using GHelper.Peripherals.Mouse.Models;
+using System.Runtime.CompilerServices;
 
 namespace GHelper.Peripherals
 {

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -814,6 +814,7 @@ namespace GHelper
             string battery = "";
 
             HardwareControl.ReadSensors();
+            Task.Run((Action)PeripheralsProvider.RefreshBatteryForAllDevices);
 
             if (HardwareControl.cpuTemp > 0)
                 cpuTemp = ": " + Math.Round((decimal)HardwareControl.cpuTemp).ToString() + "°C";

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -236,7 +236,7 @@ namespace GHelper
             {
                 screenControl.InitScreen();
                 gpuControl.InitXGM();
-                PeripheralsProvider.RefreshBatteryForAllDevices();
+                Task.Run((Action)PeripheralsProvider.RefreshBatteryForAllDevices);
                 updateControl.CheckForUpdates();
             }
         }


### PR DESCRIPTION
The deadlocks that happen with the mouse provider due to recent refactoring are now resolved.

I also re-enabled device polling during "RefreshSensors". The reason is, that this is also used to determine whether the mouse is ready for setting changes. The mouse sends no event when it gets turned off. The dongle still stays there and no HID device event is raised. You only know by reading the mouse and finding out that the mouse responds with empty packets.
The performance impact should be negligible as it runs on a separate thread and even that only takes a few ms.

I also changed the calls to "RefreshBatteryForAllDevices" to run in async tasks as the constant USB traffic for refreshing should still not run on main thread. It could lock the UI if the device is slow to respond.

Also fixed a crash if you close the window while the battery gets updated.