### PR TITLE
Auto refresh mice when hovering the button

### DIFF
--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -188,6 +188,10 @@ namespace GHelper
             buttonPeripheral2.Click += ButtonPeripheral_Click;
             buttonPeripheral3.Click += ButtonPeripheral_Click;
 
+            buttonPeripheral1.MouseEnter += ButtonPeripheral_MouseEnter;
+            buttonPeripheral2.MouseEnter += ButtonPeripheral_MouseEnter;
+            buttonPeripheral3.MouseEnter += ButtonPeripheral_MouseEnter;
+
             Text = "G-Helper " + (ProcessHelper.IsUserAdministrator() ? "—" : "-") + " " + AppConfig.GetModelShort();
             TopMost = AppConfig.Is("topmost");
 
@@ -1127,6 +1131,26 @@ namespace GHelper
             }
 
             panelPeripherals.Visible = true;
+        }
+
+        private void ButtonPeripheral_MouseEnter(object? sender, EventArgs e)
+        {
+            int index = 0;
+            if (sender == buttonPeripheral2) index = 1;
+            if (sender == buttonPeripheral3) index = 2;
+            IPeripheral iph = PeripheralsProvider.AllPeripherals().ElementAt(index);
+
+
+            if (iph is null)
+            {
+                return;
+            }
+
+            if (!iph.IsDeviceReady)
+            {
+                //Refresh battery on hover if the device is marked as "Not Ready"
+                iph.ReadBattery();
+            }
         }
 
         private void ButtonPeripheral_Click(object? sender, EventArgs e)


### PR DESCRIPTION
As I made the mouse refresh time longer, mice can stay longer in the "Not connected" state if the mouse was in standby.

To accommodate for this, the mouse is refreshed automatically when the mouse hovers the button for the device and the mouse is marked as "Not ready".
Otherwise the user had to wait 20s or close and re-open the GHelper window.