### PR TITLE
Added Rog Keris Wireless

### DIFF
--- a/app/Peripherals/Mouse/Models/ROGKerisWireless.cs
+++ b/app/Peripherals/Mouse/Models/ROGKerisWireless.cs
@@ -1,0 +1,169 @@
+﻿namespace GHelper.Peripherals.Mouse.Models
+{
+    //P513
+    public class ROGKerisWireless : AsusMouse
+    {
+        public ROGKerisWireless() : base(0x0B05, 0x1960, "mi_00", true)
+        {
+        }
+
+        protected ROGKerisWireless(ushort vendorId, bool wireless) : base(0x0B05, vendorId, "mi_00", wireless)
+        {
+        }
+
+        public override int DPIProfileCount()
+        {
+            return 4;
+        }
+
+        public override string GetDisplayName()
+        {
+            return "ROG Keris (Wireless)";
+        }
+
+
+        public override PollingRate[] SupportedPollingrates()
+        {
+            return new PollingRate[] {
+                PollingRate.PR125Hz,
+                PollingRate.PR250Hz,
+                PollingRate.PR500Hz,
+                PollingRate.PR1000Hz
+            };
+        }
+
+        public override int ProfileCount()
+        {
+            return 3;
+        }
+        public override int MaxDPI()
+        {
+            return 16_000;
+        }
+
+        public override bool HasLiftOffSetting()
+        {
+            return true;
+        }
+
+        public override bool HasRGB()
+        {
+            return true;
+        }
+
+        public override bool HasAutoPowerOff()
+        {
+            return true;
+        }
+
+        public override bool HasAngleSnapping()
+        {
+            return true;
+        }
+
+        public override bool HasAngleTuning()
+        {
+            return false;
+        }
+
+        public override bool HasLowBatteryWarning()
+        {
+            return true;
+        }
+
+        public override bool HasDPIColors()
+        {
+            return false;
+        }
+
+        public override bool IsLightingModeSupported(LightingMode lightingMode)
+        {
+            return lightingMode == LightingMode.Static
+                || lightingMode == LightingMode.Breathing
+                || lightingMode == LightingMode.ColorCycle
+                || lightingMode == LightingMode.React
+                || lightingMode == LightingMode.BatteryState
+                || lightingMode == LightingMode.Off;
+        }
+
+        //Has 25% increments
+        protected override int ParseBattery(byte[] packet)
+        {
+            if (packet[1] == 0x12 && packet[2] == 0x07)
+            {
+                return packet[5] * 25;
+            }
+
+            return -1;
+        }
+
+
+        public override int DPIIncrements()
+        {
+            return 100;
+        }
+
+        public override bool CanChangeDPIProfile()
+        {
+            return false;
+        }
+
+        protected override byte[] GetUpdateEnergySettingsPacket(int lowBatteryWarning, PowerOffSetting powerOff)
+        {
+            return base.GetUpdateEnergySettingsPacket(lowBatteryWarning / 25, powerOff);
+        }
+
+        protected override int ParseLowBatteryWarning(byte[] packet)
+        {
+            int lowBat = base.ParseLowBatteryWarning(packet);
+
+            return lowBat * 25;
+        }
+
+        protected override LiftOffDistance ParseLiftOffDistance(byte[] packet)
+        {
+            if (packet[1] != 0x12 || packet[2] != 0x06)
+            {
+                return LiftOffDistance.Low;
+            }
+
+            return (LiftOffDistance)packet[5];
+        }
+
+        protected override byte[] GetUpdateLiftOffDistancePacket(LiftOffDistance liftOffDistance)
+        {
+            return new byte[] { 0x00, 0x51, 0x35, 0x00, 0x00, ((byte)liftOffDistance) };
+        }
+
+        public override LightingZone[] SupportedLightingZones()
+        {
+            return new LightingZone[] { LightingZone.Logo, LightingZone.Scrollwheel };
+        }
+
+        public override int MaxBrightness()
+        {
+            return 4;
+        }
+
+        protected override byte IndexForLightingMode(LightingMode lightingMode)
+        {
+            if (lightingMode == LightingMode.Off)
+            {
+                return 0xFF;
+            }
+            return ((byte)lightingMode);
+        }
+    }
+
+    public class ROGKerisWirelessWired : ROGKerisWireless
+    {
+        public ROGKerisWirelessWired() : base(0x195E, false)
+        {
+        }
+
+        public override string GetDisplayName()
+        {
+            return "ROG Keris (Wired)";
+        }
+    }
+}

--- a/app/Peripherals/PeripheralsProvider.cs
+++ b/app/Peripherals/PeripheralsProvider.cs
@@ -187,6 +187,8 @@ namespace GHelper.Peripherals
             DetectMouse(new ChakramXWired());
             DetectMouse(new GladiusIIIAimpoint());
             DetectMouse(new GladiusIIIAimpointWired());
+            DetectMouse(new ROGKerisWireless());
+            DetectMouse(new ROGKerisWirelessWired());
             DetectMouse(new TUFM4Wirelss());
         }
 


### PR DESCRIPTION
This adds the ROG Keris wireless with _almost_ full support.

One issue is here: You cannot switch the DPI profile. You can do it via the mouse buttons but the mouse does not respond on the AC interface for DPI switching via GHelper. We tested a lot and haven't found any clue how AC does it. There is 0 traffic over the USB Bus that indicates a DPI profile change. The default endpoints, that even work on mice without AC support for DPI switching (like the TUF M4) error out on this mouse (mouse responds with FF AA, which seems to be a general "I don't understand that packet" message). Either it is a firmware bug or ASUS did something goofy here.

We might have to document that for the mouse support. Everything else works fine for this mouse as tested by @1m4g1ne.
