### PR TITLE
Mouse support fixes

### DIFF
--- a/app/AsusMouseSettings.Designer.cs
+++ b/app/AsusMouseSettings.Designer.cs
@@ -60,7 +60,7 @@
             labelPerformance = new Label();
             panelLighting = new Panel();
             panelLightingContent = new Panel();
-            tableLayoutPanel3 = new TableLayoutPanel();
+            tableLayoutLightingZones = new TableLayoutPanel();
             buttonLightingZoneScroll = new UI.RButton();
             buttonLightingZoneLogo = new UI.RButton();
             buttonLightingZoneAll = new UI.RButton();
@@ -111,7 +111,7 @@
             ((System.ComponentModel.ISupportInitialize)pictureKeyboard).BeginInit();
             panelLighting.SuspendLayout();
             panelLightingContent.SuspendLayout();
-            tableLayoutPanel3.SuspendLayout();
+            tableLayoutLightingZones.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)pictureBoxLightingColor).BeginInit();
             panelLightingHeader.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)pictureBoxLighting).BeginInit();
@@ -570,7 +570,7 @@
             // panelLightingContent
             // 
             panelLightingContent.AutoSize = true;
-            panelLightingContent.Controls.Add(tableLayoutPanel3);
+            panelLightingContent.Controls.Add(tableLayoutLightingZones);
             panelLightingContent.Controls.Add(comboBoxAnimationDirection);
             panelLightingContent.Controls.Add(labelAnimationDirection);
             panelLightingContent.Controls.Add(checkBoxRandomColor);
@@ -587,29 +587,29 @@
             panelLightingContent.Size = new Size(654, 274);
             panelLightingContent.TabIndex = 42;
             // 
-            // tableLayoutPanel3
+            // tableLayoutLightingZones
             // 
-            tableLayoutPanel3.AutoSize = true;
-            tableLayoutPanel3.AutoSizeMode = AutoSizeMode.GrowAndShrink;
-            tableLayoutPanel3.ColumnCount = 5;
-            tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20F));
-            tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20F));
-            tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20F));
-            tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20F));
-            tableLayoutPanel3.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20F));
-            tableLayoutPanel3.Controls.Add(buttonLightingZoneScroll, 0, 0);
-            tableLayoutPanel3.Controls.Add(buttonLightingZoneLogo, 0, 0);
-            tableLayoutPanel3.Controls.Add(buttonLightingZoneAll, 0, 0);
-            tableLayoutPanel3.Controls.Add(buttonLightingZoneUnderglow, 1, 0);
-            tableLayoutPanel3.Controls.Add(buttonLightingZoneDock, 2, 0);
-            tableLayoutPanel3.Dock = DockStyle.Top;
-            tableLayoutPanel3.Location = new Point(0, 0);
-            tableLayoutPanel3.Margin = new Padding(6, 3, 6, 3);
-            tableLayoutPanel3.Name = "tableLayoutPanel3";
-            tableLayoutPanel3.RowCount = 1;
-            tableLayoutPanel3.RowStyles.Add(new RowStyle(SizeType.Absolute, 60F));
-            tableLayoutPanel3.Size = new Size(654, 60);
-            tableLayoutPanel3.TabIndex = 56;
+            tableLayoutLightingZones.AutoSize = true;
+            tableLayoutLightingZones.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            tableLayoutLightingZones.ColumnCount = 5;
+            tableLayoutLightingZones.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20F));
+            tableLayoutLightingZones.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20F));
+            tableLayoutLightingZones.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20F));
+            tableLayoutLightingZones.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20F));
+            tableLayoutLightingZones.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 20F));
+            tableLayoutLightingZones.Controls.Add(buttonLightingZoneScroll, 0, 0);
+            tableLayoutLightingZones.Controls.Add(buttonLightingZoneLogo, 0, 0);
+            tableLayoutLightingZones.Controls.Add(buttonLightingZoneAll, 0, 0);
+            tableLayoutLightingZones.Controls.Add(buttonLightingZoneUnderglow, 1, 0);
+            tableLayoutLightingZones.Controls.Add(buttonLightingZoneDock, 2, 0);
+            tableLayoutLightingZones.Dock = DockStyle.Top;
+            tableLayoutLightingZones.Location = new Point(0, 0);
+            tableLayoutLightingZones.Margin = new Padding(6, 3, 6, 3);
+            tableLayoutLightingZones.Name = "tableLayoutLightingZones";
+            tableLayoutLightingZones.RowCount = 1;
+            tableLayoutLightingZones.RowStyles.Add(new RowStyle(SizeType.Absolute, 60F));
+            tableLayoutLightingZones.Size = new Size(654, 60);
+            tableLayoutLightingZones.TabIndex = 56;
             // 
             // buttonLightingZoneScroll
             // 
@@ -1179,8 +1179,8 @@
             panelLighting.PerformLayout();
             panelLightingContent.ResumeLayout(false);
             panelLightingContent.PerformLayout();
-            tableLayoutPanel3.ResumeLayout(false);
-            tableLayoutPanel3.PerformLayout();
+            tableLayoutLightingZones.ResumeLayout(false);
+            tableLayoutLightingZones.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)pictureBoxLightingColor).EndInit();
             panelLightingHeader.ResumeLayout(false);
             panelLightingHeader.PerformLayout();
@@ -1263,7 +1263,7 @@
         private UI.RButton buttonSync;
         private Panel panelBottomButtons;
         private NumericUpDown numericUpDownCurrentDPI;
-        private TableLayoutPanel tableLayoutPanel3;
+        private TableLayoutPanel tableLayoutLightingZones;
         private UI.RButton buttonLightingZoneScroll;
         private UI.RButton buttonLightingZoneLogo;
         private UI.RButton buttonLightingZoneAll;

--- a/app/AsusMouseSettings.cs
+++ b/app/AsusMouseSettings.cs
@@ -173,6 +173,11 @@ namespace GHelper
 
         private void ComboProfile_DropDownClosed(object? sender, EventArgs e)
         {
+            if (mouse.Profile == comboProfile.SelectedIndex)
+            {
+                return;
+            }
+
             mouse.SetProfile(comboProfile.SelectedIndex);
             Task task = Task.Run((Action)RefreshMouseData);
         }

--- a/app/AsusMouseSettings.cs
+++ b/app/AsusMouseSettings.cs
@@ -532,10 +532,20 @@ namespace GHelper
 
             if (mouse.HasRGB())
             {
-                buttonLightingZoneLogo.Visible = mouse.SupportedLightingZones().Contains(LightingZone.Logo);
-                buttonLightingZoneScroll.Visible = mouse.SupportedLightingZones().Contains(LightingZone.Scrollwheel);
-                buttonLightingZoneUnderglow.Visible = mouse.SupportedLightingZones().Contains(LightingZone.Underglow);
-                buttonLightingZoneDock.Visible = mouse.SupportedLightingZones().Contains(LightingZone.Dock);
+                if (mouse.SupportedLightingZones().Length > 1)
+                {
+                    buttonLightingZoneLogo.Visible = mouse.SupportedLightingZones().Contains(LightingZone.Logo);
+                    buttonLightingZoneScroll.Visible = mouse.SupportedLightingZones().Contains(LightingZone.Scrollwheel);
+                    buttonLightingZoneUnderglow.Visible = mouse.SupportedLightingZones().Contains(LightingZone.Underglow);
+                    buttonLightingZoneDock.Visible = mouse.SupportedLightingZones().Contains(LightingZone.Dock);
+                }
+                else
+                {
+                    buttonLightingZoneLogo.Visible = false;
+                    buttonLightingZoneScroll.Visible = false;
+                    buttonLightingZoneUnderglow.Visible = false;
+                    buttonLightingZoneDock.Visible = false;
+                }
 
                 sliderBrightness.Max = mouse.MaxBrightness();
 

--- a/app/Peripherals/Mouse/AsusMouse.cs
+++ b/app/Peripherals/Mouse/AsusMouse.cs
@@ -174,7 +174,15 @@ namespace GHelper.Peripherals.Mouse
             this.path = path;
             this.Wireless = wireless;
             DpiSettings = new AsusMouseDPI[1];
-            LightingSetting = new LightingSetting[SupportedLightingZones().Length];
+            if (SupportedLightingZones().Length == 0)
+            {
+                LightingSetting = new LightingSetting[1];
+            }
+            else
+            {
+                LightingSetting = new LightingSetting[SupportedLightingZones().Length];
+            }
+
         }
 
         public override bool Equals(object? obj)
@@ -1068,7 +1076,7 @@ namespace GHelper.Peripherals.Mouse
 
         public virtual LightingZone[] SupportedLightingZones()
         {
-            return new LightingZone[] { };
+            return new LightingZone[] { LightingZone.Logo };
         }
 
         public virtual int IndexForZone(LightingZone zone)
@@ -1086,6 +1094,11 @@ namespace GHelper.Peripherals.Mouse
 
         public virtual bool IsLightingZoned()
         {
+            if (LightingSetting.Length < 2)
+            {
+                return false;
+            }
+
             //Check whether all zones are the same or not
             for (int i = 1; i < LightingSetting.Length; ++i)
             {


### PR DESCRIPTION
This fixes two issues.

1) For mice like the keris that do not support DPI switching, it now allows do switch through the profiles in GHelper to edit all the profiles without having to press the button on the mouse

2) Mice with only a single lighting zone only show the "All" zone.

3) Closing the profile drop down only switches the mouse profile if the profile is different. This reduces unnecessary calls to the mouse firmware.