### PR TITLE
Adds support for Gladius III Wireless (P706_Wireless).

### DIFF
--- a/app/AsusMouseSettings.cs
+++ b/app/AsusMouseSettings.cs
@@ -196,7 +196,7 @@ namespace GHelper
             }
 
             mouse.SetProfile(comboProfile.SelectedIndex);
-            Task task = Task.Run((Action)RefreshMouseData);
+            RefreshMouseData();
         }
 
         private void ComboBoxPollingRate_DropDownClosed(object? sender, EventArgs e)
@@ -408,13 +408,13 @@ namespace GHelper
 
         private void Mouse_Disconnect(object? sender, EventArgs e)
         {
+            if (Disposing || IsDisposed)
+            {
+                return;
+            }
             //Mouse disconnected. Bye bye.
             this.Invoke(delegate
             {
-                if (Disposing || IsDisposed)
-                {
-                    return;
-                }
                 this.Close();
             });
 
@@ -428,18 +428,17 @@ namespace GHelper
             if (!mouse.IsDeviceReady)
             {
                 Logger.WriteLine(mouse.GetDisplayName() + " (GUI): Mouse is not ready. Closing view.");
-                this.Invoke(delegate
-                {
-                    this.Close();
-                });
+                Mouse_Disconnect(this, EventArgs.Empty);
                 return;
             }
 
-            this.Invoke(delegate
+            if (Disposing || IsDisposed)
             {
-                VisualizeMouseSettings();
-                VisualizeBatteryState();
-            });
+                return;
+            }
+
+            VisualizeMouseSettings();
+            VisualizeBatteryState();
         }
 
         private void InitMouseCapabilities()
@@ -821,7 +820,7 @@ namespace GHelper
 
         private void ButtonSync_Click(object sender, EventArgs e)
         {
-            Task task = Task.Run((Action)RefreshMouseData);
+            RefreshMouseData();
         }
     }
 }

--- a/app/Peripherals/Mouse/Models/GladiusIII.cs
+++ b/app/Peripherals/Mouse/Models/GladiusIII.cs
@@ -1,13 +1,13 @@
 ﻿namespace GHelper.Peripherals.Mouse.Models
 {
-    //P711
-    public class GladiusIIIAimpoint : AsusMouse
+    //P706_Wireless
+    public class GladiusIII : AsusMouse
     {
-        public GladiusIIIAimpoint() : base(0x0B05, 0x1A70, "mi_00", true)
+        public GladiusIII() : base(0x0B05, 0x197F, "mi_00", true)
         {
         }
 
-        protected GladiusIIIAimpoint(ushort vendorId, bool wireless) : base(0x0B05, vendorId, "mi_00", wireless)
+        protected GladiusIII(ushort vendorId, bool wireless) : base(0x0B05, vendorId, "mi_00", wireless)
         {
         }
 
@@ -18,7 +18,7 @@
 
         public override string GetDisplayName()
         {
-            return "ROG Gladius III Aimpoint (Wireless)";
+            return "ROG Gladius III (Wireless)";
         }
 
 
@@ -38,12 +38,7 @@
         }
         public override int MaxDPI()
         {
-            return 36_000;
-        }
-
-        public override bool HasXYDPI()
-        {
-            return true;
+            return 26_000;
         }
 
         public override bool HasDebounceSetting()
@@ -76,31 +71,21 @@
             return true;
         }
 
-        public override bool HasAngleTuning()
-        {
-            return true;
-        }
-
         public override bool HasLowBatteryWarning()
-        {
-            return true;
-        }
-
-        public override bool HasDPIColors()
         {
             return true;
         }
     }
 
-    public class GladiusIIIAimpointWired : GladiusIIIAimpoint
+    public class GladiusIIIWired : GladiusIII
     {
-        public GladiusIIIAimpointWired() : base(0x1A72, false)
+        public GladiusIIIWired() : base(0x197d, false)
         {
         }
 
         public override string GetDisplayName()
         {
-            return "ROG Gladius III Aimpoint (Wired)";
+            return "ROG Gladius III (Wired)";
         }
     }
 }

--- a/app/Peripherals/PeripheralsProvider.cs
+++ b/app/Peripherals/PeripheralsProvider.cs
@@ -192,6 +192,8 @@ namespace GHelper.Peripherals
             DetectMouse(new TUFM4Wirelss());
             DetectMouse(new StrixImpactIIWireless());
             DetectMouse(new StrixImpactIIWirelessWired());
+            DetectMouse(new GladiusIII());
+            DetectMouse(new GladiusIIIWired());
         }
 
         public static void DetectMouse(AsusMouse am)


### PR DESCRIPTION
Adds support for Gladius III Wireless (P706_Wireless).
Renamed the other Gladius III (P711) to Gladius III Wireless Aimpoint to differentiate them (yeah, ASUS product names are not confusing at all)
Fixes a bug that can crash G-Helper when opening the mouse window.