### PR TITLE
TUF Gaming M3 support

### DIFF
--- a/app/AsusMouseSettings.cs
+++ b/app/AsusMouseSettings.cs
@@ -503,6 +503,9 @@ namespace GHelper
             {
                 labelAngleAdjustmentValue.Visible = false;
                 sliderAngleAdjustment.Visible = false;
+                sliderAngleAdjustment.Max = mouse.AngleTuningMax();
+                sliderAngleAdjustment.Min = mouse.AngleTuningMin();
+                sliderAngleAdjustment.Step = mouse.AngleTuningStep();
             }
 
             if (!mouse.HasAngleTuning() && !mouse.HasAngleSnapping())

--- a/app/Peripherals/Mouse/AsusMouse.cs
+++ b/app/Peripherals/Mouse/AsusMouse.cs
@@ -615,6 +615,21 @@ namespace GHelper.Peripherals.Mouse
             return false;
         }
 
+        public virtual int AngleTuningStep()
+        {
+            return 1;
+        }
+
+        public virtual int AngleTuningMin()
+        {
+            return -20;
+        }
+
+        public virtual int AngleTuningMax()
+        {
+            return 20;
+        }
+
         public virtual string PollingRateDisplayString(PollingRate pollingRate)
         {
             return POLLING_RATES[(int)pollingRate];
@@ -762,9 +777,10 @@ namespace GHelper.Peripherals.Mouse
                 return;
             }
 
-            if (angleAdjustment < -20 || angleAdjustment > 20)
+            if (angleAdjustment < AngleTuningMin() || angleAdjustment > AngleTuningMax())
             {
-                Logger.WriteLine(GetDisplayName() + ": Angle Adjustment:" + angleAdjustment + " is outside of range [-20;20].");
+                Logger.WriteLine(GetDisplayName() + ": Angle Adjustment:" + angleAdjustment
+                    + " is outside of range [" + AngleTuningMin() + "; " + AngleTuningMax() + "].");
                 return;
             }
 

--- a/app/Peripherals/Mouse/AsusMouse.cs
+++ b/app/Peripherals/Mouse/AsusMouse.cs
@@ -140,7 +140,7 @@ namespace GHelper.Peripherals.Mouse
     public abstract class AsusMouse : Device, IPeripheral
     {
         private static string[] POLLING_RATES = { "125 Hz", "250 Hz", "500 Hz", "1000 Hz", "2000 Hz", "4000 Hz", "8000 Hz", "16000 Hz" };
-        internal const bool PACKET_LOGGER_ALWAYS_ON = true;
+        internal const bool PACKET_LOGGER_ALWAYS_ON = false;
         internal const int ASUS_MOUSE_PACKET_SIZE = 65;
 
         public event EventHandler? Disconnect;

--- a/app/Peripherals/Mouse/Models/TUFM3.cs
+++ b/app/Peripherals/Mouse/Models/TUFM3.cs
@@ -1,0 +1,112 @@
+﻿namespace GHelper.Peripherals.Mouse.Models
+{
+    //P306_Wireless
+    public class TUFM3 : AsusMouse
+    {
+        public TUFM3() : base(0x0B05, 0x1910, "mi_01", false)
+        {
+        }
+
+        public override int DPIProfileCount()
+        {
+            return 4;
+        }
+
+        public override string GetDisplayName()
+        {
+            return "TUF GAMING M3";
+        }
+
+
+        public override PollingRate[] SupportedPollingrates()
+        {
+            return new PollingRate[] {
+                PollingRate.PR125Hz,
+                PollingRate.PR250Hz,
+                PollingRate.PR500Hz,
+                PollingRate.PR1000Hz
+            };
+        }
+
+        //Mouse has React mapped to 0x03 instead of 0x04 like other mice
+        protected override byte IndexForLightingMode(LightingMode lightingMode)
+        {
+            if (lightingMode == LightingMode.React)
+            {
+                return 0x03;
+            }
+            return ((byte)lightingMode);
+        }
+
+        //Mouse has React mapped to 0x03 instead of 0x04 like other mice
+        protected override LightingMode LightingModeForIndex(byte lightingMode)
+        {
+            if (lightingMode == 0x03)
+            {
+                return LightingMode.React;
+            }
+            return base.LightingModeForIndex(lightingMode);
+
+        }
+
+        public override int ProfileCount()
+        {
+            return 1;
+        }
+        public override int MaxDPI()
+        {
+            return 7_000;
+        }
+        public override bool HasBattery()
+        {
+            return false;
+        }
+
+        public override bool HasLiftOffSetting()
+        {
+            return false;
+        }
+        public override LightingZone[] SupportedLightingZones()
+        {
+            return new LightingZone[] { LightingZone.Logo };
+        }
+
+        public override bool HasRGB()
+        {
+            return true;
+        }
+
+        public override bool HasAngleSnapping()
+        {
+            return true;
+        }
+
+        public override int DPIIncrements()
+        {
+            return 100;
+        }
+
+        public override bool CanChangeDPIProfile()
+        {
+            return true;
+        }
+
+        public override bool HasDebounceSetting()
+        {
+            return true;
+        }
+
+        public override int MaxBrightness()
+        {
+            return 4;
+        }
+
+        public override bool IsLightingModeSupported(LightingMode lightingMode)
+        {
+            return lightingMode == LightingMode.Static
+                || lightingMode == LightingMode.Breathing
+                || lightingMode == LightingMode.ColorCycle
+                || lightingMode == LightingMode.React;
+        }
+    }
+}

--- a/app/Peripherals/PeripheralsProvider.cs
+++ b/app/Peripherals/PeripheralsProvider.cs
@@ -194,6 +194,7 @@ namespace GHelper.Peripherals
             DetectMouse(new StrixImpactIIWirelessWired());
             DetectMouse(new GladiusIII());
             DetectMouse(new GladiusIIIWired());
+            DetectMouse(new TUFM3());
         }
 
         public static void DetectMouse(AsusMouse am)


### PR DESCRIPTION
Adds support for the TUF Gaming M3 Mouse.
This also removes the hardcoded packet logger (left it in by accident...ooops) and falls back to the configuration option.