### PR TITLE
RC71/ally: don't hook the volume keys / translate them to M1/M2

### DIFF
--- a/app/Input/InputDispatcher.cs
+++ b/app/Input/InputDispatcher.cs
@@ -104,7 +104,9 @@ namespace GHelper.Input
             if (keyProfile != Keys.None) hook.RegisterHotKey(ModifierKeys.Shift | ModifierKeys.Control, keyProfile);
             if (keyApp != Keys.None) hook.RegisterHotKey(ModifierKeys.Shift | ModifierKeys.Control, keyApp);
 
-            if (!AppConfig.Is("skip_hotkeys"))
+            // Note: we don't register Vol-/+ hooks on the ROG ALly, since those keys are
+            // generated correctly, and necessary in the Ally's use case.
+            if (!AppConfig.Is("skip_hotkeys") && !AppConfig.ContainsModel("RC71"))
             {
                 hook.RegisterHotKey(ModifierKeys.Control, Keys.VolumeDown);
                 hook.RegisterHotKey(ModifierKeys.Control, Keys.VolumeUp);
@@ -112,7 +114,7 @@ namespace GHelper.Input
                 hook.RegisterHotKey(ModifierKeys.Shift, Keys.VolumeUp);
             }
 
-            if (!AppConfig.ContainsModel("Z13"))
+            if (!AppConfig.ContainsModel("Z13") && !AppConfig.ContainsModel("RC71"))
             {
                 if (actionM1 is not null && actionM1.Length > 0) hook.RegisterHotKey(ModifierKeys.None, Keys.VolumeDown);
                 if (actionM2 is not null && actionM2.Length > 0) hook.RegisterHotKey(ModifierKeys.None, Keys.VolumeUp);


### PR DESCRIPTION
Quick fix for the volume buttons also being read as M1/M2.