### PR TITLE
Dark/Light Mode override

### DIFF
--- a/app/UI/CustomControls.cs
+++ b/app/UI/CustomControls.cs
@@ -62,6 +62,16 @@ namespace GHelper.UI
 
         private static bool IsDarkTheme()
         {
+            if (AppConfig.GetString("ui_mode").ToLower() == "dark")
+            {
+                return true;
+            }
+
+            if (AppConfig.GetString("ui_mode").ToLower() == "light")
+            {
+                return false;
+            }
+
             using var key = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize");
             var registryValueObject = key?.GetValue("AppsUseLightTheme");
 

--- a/app/UI/CustomControls.cs
+++ b/app/UI/CustomControls.cs
@@ -62,12 +62,14 @@ namespace GHelper.UI
 
         private static bool IsDarkTheme()
         {
-            if (AppConfig.GetString("ui_mode").ToLower() == "dark")
+            string? uiMode = AppConfig.GetString("ui_mode");
+
+            if (uiMode is not null && uiMode.ToLower() == "dark")
             {
                 return true;
             }
 
-            if (AppConfig.GetString("ui_mode").ToLower() == "light")
+            if (uiMode is not null && uiMode.ToLower() == "light")
             {
                 return false;
             }


### PR DESCRIPTION
With the recent changes, my setting (dark taskbar, light window) results in light GHelper which was dark before.

So, I added an option to override the light/dark mode detection in the config file.

The setting is called `ui_mode` and can be either `dark `or `light` (case-insensitive) to override the default design. Everything else, or omitting the setting, will result in the current behavior, which is auto detection.