### PR TITLE
Added windows based dark mode detection via config override

### DIFF
--- a/app/UI/CustomControls.cs
+++ b/app/UI/CustomControls.cs
@@ -74,6 +74,11 @@ namespace GHelper.UI
                 return false;
             }
 
+            if (uiMode is not null && uiMode.ToLower() == "windows")
+            {
+                return CheckSystemDarkModeStatus();
+            }
+
             using var key = Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize");
             var registryValueObject = key?.GetValue("AppsUseLightTheme");
 


### PR DESCRIPTION
A change that @AudreyAP  requested. 
If you now specify `windows` for `ui_mode` it effectively behaves like it did before the dark mode "fix". This means, it follows the system dark mode state, not the one for apps.

Like before, specifying nothing or anything besides `dark`, `light` or `windows` will do nothing and follow the default behavior, which means: App dark mode