### PR TITLE
Support for ROG Harpe Ace Aim Lab Edition (P713).

### DIFF
--- a/app/Peripherals/Mouse/AsusMouse.cs
+++ b/app/Peripherals/Mouse/AsusMouse.cs
@@ -141,7 +141,6 @@ namespace GHelper.Peripherals.Mouse
     {
         private static string[] POLLING_RATES = { "125 Hz", "250 Hz", "500 Hz", "1000 Hz", "2000 Hz", "4000 Hz", "8000 Hz", "16000 Hz" };
         internal const bool PACKET_LOGGER_ALWAYS_ON = false;
-        internal const int ASUS_MOUSE_PACKET_SIZE = 65;
 
         public event EventHandler? Disconnect;
         public event EventHandler? BatteryUpdated;
@@ -274,6 +273,11 @@ namespace GHelper.Peripherals.Mouse
             return 300;
         }
 
+        public virtual int USBPacketSize()
+        {
+            return 65;
+        }
+
         public override void SetProvider()
         {
             _usbProvider = new WindowsUsbProvider(_vendorId, _productId, path, USBTimeout());
@@ -316,16 +320,17 @@ namespace GHelper.Peripherals.Mouse
         [MethodImpl(MethodImplOptions.Synchronized)]
         protected virtual byte[]? WriteForResponse(byte[] packet)
         {
-            Array.Resize(ref packet, ASUS_MOUSE_PACKET_SIZE);
+            Array.Resize(ref packet, USBPacketSize());
 
 
-            byte[] response = new byte[ASUS_MOUSE_PACKET_SIZE];
+            byte[] response = new byte[USBPacketSize()];
+            response[0] = reportId;
 
             int retries = 3;
 
             while (retries > 0)
             {
-                response = new byte[ASUS_MOUSE_PACKET_SIZE];
+                response = new byte[USBPacketSize()];
 
                 try
                 {

--- a/app/Peripherals/Mouse/Models/HarpeAceAimLab.cs
+++ b/app/Peripherals/Mouse/Models/HarpeAceAimLab.cs
@@ -1,0 +1,174 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace GHelper.Peripherals.Mouse.Models
+{
+    //P713_Wireless
+    public class HarpeAceAimLabEdition : AsusMouse
+    {
+        public HarpeAceAimLabEdition() : base(0x0B05, 0x1A94, "mi_00", true)
+        {
+        }
+
+        protected HarpeAceAimLabEdition(ushort productId, bool wireless, string endpoint, byte reportId) : base(0x0B05, productId, endpoint, wireless, reportId)
+        {
+        }
+
+        public override int DPIProfileCount()
+        {
+            return 4;
+        }
+
+        public override string GetDisplayName()
+        {
+            return "ROG Harpe Ace Aim Lab Edition (Wireless)";
+        }
+
+
+        public override PollingRate[] SupportedPollingrates()
+        {
+            return new PollingRate[] {
+                PollingRate.PR125Hz,
+                PollingRate.PR250Hz,
+                PollingRate.PR500Hz,
+                PollingRate.PR1000Hz
+            };
+        }
+
+        public override int ProfileCount()
+        {
+            return 5;
+        }
+        public override int MaxDPI()
+        {
+            return 36_000;
+        }
+
+        public override int MinDPI()
+        {
+            return 50;
+        }
+
+        public override bool HasXYDPI()
+        {
+            return true;
+        }
+
+        public override bool HasDebounceSetting()
+        {
+            return true;
+        }
+
+        public override bool HasLiftOffSetting()
+        {
+            return true;
+        }
+
+        public override bool HasRGB()
+        {
+            return true;
+        }
+
+        public override LightingZone[] SupportedLightingZones()
+        {
+            return new LightingZone[] { LightingZone.Scrollwheel };
+        }
+
+        public override bool IsLightingModeSupported(LightingMode lightingMode)
+        {
+            return lightingMode == LightingMode.Static
+                || lightingMode == LightingMode.Breathing
+                || lightingMode == LightingMode.ColorCycle
+                || lightingMode == LightingMode.React
+                || lightingMode == LightingMode.BatteryState
+                || lightingMode == LightingMode.Off;
+        }
+
+        public override bool HasAutoPowerOff()
+        {
+            return true;
+        }
+
+        public override bool HasAngleSnapping()
+        {
+            return true;
+        }
+
+        public override bool HasAngleTuning()
+        {
+            return true;
+        }
+
+        public override bool HasLowBatteryWarning()
+        {
+            return true;
+        }
+
+        public override bool HasDPIColors()
+        {
+            return true;
+        }
+
+        public override int AngleTuningStep()
+        {
+            return 1;
+        }
+
+        public override int AngleTuningMin()
+        {
+            return -30;
+        }
+
+        public override int AngleTuningMax()
+        {
+            return 30;
+        }
+
+        public override bool HasAcceleration()
+        {
+            return true;
+        }
+
+        public override bool HasDeceleration()
+        {
+            return true;
+        }
+
+        public override int MaxAcceleration()
+        {
+            return 9;
+        }
+        public override int MaxDeceleration()
+        {
+            return 9;
+        }
+    }
+
+    public class HarpeAceAimLabEditionWired : HarpeAceAimLabEdition
+    {
+        public HarpeAceAimLabEditionWired() : base(0x1A92, false, "mi_00", 0x00)
+        {
+        }
+
+        public override string GetDisplayName()
+        {
+            return "ROG Harpe Ace Aim Lab Edition (Wired)";
+        }
+    }
+
+    public class HarpeAceAimLabEditionOmni : HarpeAceAimLabEdition
+    {
+        public HarpeAceAimLabEditionOmni() : base(0x1ACE, true, "mi_02&col03", 0x03)
+        {
+        }
+
+        public override string GetDisplayName()
+        {
+            return "ROG Harpe Ace Aim Lab Edition (OMNI)";
+        }
+
+        public override int USBPacketSize()
+        {
+            return 64;
+        }
+    }
+}

--- a/app/Peripherals/PeripheralsProvider.cs
+++ b/app/Peripherals/PeripheralsProvider.cs
@@ -196,6 +196,9 @@ namespace GHelper.Peripherals
             DetectMouse(new StrixImpactIIWirelessWired());
             DetectMouse(new GladiusIII());
             DetectMouse(new GladiusIIIWired());
+            DetectMouse(new HarpeAceAimLabEdition());
+            DetectMouse(new HarpeAceAimLabEditionWired());
+            DetectMouse(new HarpeAceAimLabEditionOmni());
             DetectMouse(new TUFM3());
             DetectMouse(new KerisWirelssAimpoint());
             DetectMouse(new KerisWirelssAimpointWired());


### PR DESCRIPTION
Mouse support for the ROG Harpe Ace Aim Lab Edition (P713). Mouse is supported wired, via wireless dongle and also through an OMNI Receiver.