### PR TITLE
Fix default fan curve buffer size

### DIFF
--- a/app/AsusACPI.cs
+++ b/app/AsusACPI.cs
@@ -254,7 +254,7 @@ public class AsusACPI
     protected byte[] CallMethod(uint MethodID, byte[] args)
     {
         byte[] acpiBuf = new byte[8 + args.Length];
-        byte[] outBuffer = new byte[20];
+        byte[] outBuffer = new byte[16];
 
         BitConverter.GetBytes((uint)MethodID).CopyTo(acpiBuf, 0);
         BitConverter.GetBytes((uint)args.Length).CopyTo(acpiBuf, 4);


### PR DESCRIPTION
When getting default fan curve by GetFanCurve(), CallMethod() returns buffer with size 20, and causes IsInvalidCurve() fail.
It seems other functions only use the first byte of returned buffer; we can safely reduce the buffer size to 16 to fix default fan curve.
