### PR TITLE
New binding to previous performance mode (CTRL + SHIFT + F21)

### DIFF
--- a/app/Input/InputDispatcher.cs
+++ b/app/Input/InputDispatcher.cs
@@ -14,6 +14,7 @@ namespace GHelper.Input
         public static bool backlightActivity = true;
 
         public static Keys keyProfile = Keys.F5;
+        public static Keys keyProfilePrevious = Keys.F21;
         public static Keys keyApp = Keys.F12;
 
         static ModeControl modeControl = Program.modeControl;
@@ -98,12 +99,14 @@ namespace GHelper.Input
 
             // CTRL + SHIFT + F5 to cycle profiles
             if (AppConfig.Get("keybind_profile") != -1) keyProfile = (Keys)AppConfig.Get("keybind_profile");
+            if (AppConfig.Get("keybind_profile_previous") != -1) keyProfilePrevious = (Keys)AppConfig.Get("keybind_profile_previous");
             if (AppConfig.Get("keybind_app") != -1) keyApp = (Keys)AppConfig.Get("keybind_app");
 
             string actionM1 = AppConfig.GetString("m1");
             string actionM2 = AppConfig.GetString("m2");
 
             if (keyProfile != Keys.None) hook.RegisterHotKey(ModifierKeys.Shift | ModifierKeys.Control, keyProfile);
+            if (keyProfilePrevious != Keys.None) hook.RegisterHotKey(ModifierKeys.Shift | ModifierKeys.Control, keyProfilePrevious);
             if (keyApp != Keys.None) hook.RegisterHotKey(ModifierKeys.Shift | ModifierKeys.Control, keyApp);
 
             if (!AppConfig.Is("skip_hotkeys"))
@@ -276,6 +279,8 @@ namespace GHelper.Input
             if (e.Modifier == (ModifierKeys.Control | ModifierKeys.Shift))
             {
                 if (e.Key == keyProfile) modeControl.CyclePerformanceMode();
+                if (e.Key == keyProfilePrevious) modeControl.ForcePreviousCyclePerformanceMode();//for ROG Ally, which doesn't have a FN key
+
                 if (e.Key == keyApp) Program.SettingsToggle();
                 if (e.Key == Keys.F20) KeyProcess("m3");
             }

--- a/app/Mode/ModeControl.cs
+++ b/app/Mode/ModeControl.cs
@@ -121,6 +121,12 @@ namespace GHelper.Mode
             SetPerformanceMode(Modes.GetNext(Control.ModifierKeys == Keys.Shift), true);
         }
 
+        //for ROG Ally, which doesn't have a FN key
+        public void ForcePreviousCyclePerformanceMode()
+        {
+            SetPerformanceMode(Modes.GetNext(true), true);
+        }
+
         public void AutoFans(bool force = false)
         {
             customFans = false;


### PR DESCRIPTION
The only thing this does is create a new binding to previous performance mode. Reason was that the ROG Ally doesn't have a FN key. I'd like to create more bindings to F13-F24 keys so that Ally users have more options to configure G-Helper. Let me know how you feel about it!