### PR TITLE
add force set gpu param

### DIFF
--- a/app/AppConfig.cs
+++ b/app/AppConfig.cs
@@ -371,4 +371,8 @@ public static class AppConfig
         return Is("gpu_fix") || (ContainsModel("GA402X") && IsNotFalse("gpu_fix"));
     }
 
+    public static bool IsForceSetGPUMode()
+    {
+        return Is("gpu_mode_force_set") || ContainsModel("503");
+    }
 }

--- a/app/Gpu/GPUModeControl.cs
+++ b/app/Gpu/GPUModeControl.cs
@@ -201,7 +201,7 @@ namespace GHelper.Gpu
         {
 
             bool GpuAuto = AppConfig.Is("gpu_auto");
-            bool ForceGPU = AppConfig.ContainsModel("503");
+            bool ForceGPU = AppConfig.IsForceSetGPUMode();
 
             int GpuMode = AppConfig.Get("gpu_mode");
 


### PR DESCRIPTION
Fix for GPU mode resetting after system restart. 

I'm having issue on my FX517 when i set GPU to Eco mode and after restarting system it's being reset to Standart. I noticed this issue in Armory Crate after one of it's updates around 8 months ago, though there are no apps that use GPU on startup.

So i propose to add parameter that will force set gpu mode, not only for 503 model.