### PR TITLE
Multi Screen position & DPI Optimize

### DIFF
--- a/app/Program.cs
+++ b/app/Program.cs
@@ -217,15 +217,18 @@ namespace GHelper
             if (settingsForm.Visible) settingsForm.HideAll();
             else
             {
+                Rectangle CurrentScreen = Screen.FromControl(settingsForm).WorkingArea;
+                Point CurrentScreenOffset = Screen.FromControl(settingsForm).WorkingArea.Location;
 
-                settingsForm.Left = Screen.FromControl(settingsForm).WorkingArea.Width - 10 - settingsForm.Width;
-                settingsForm.Top = Screen.FromControl(settingsForm).WorkingArea.Height - 10 - settingsForm.Height;
+
+                settingsForm.Left = Screen.FromControl(settingsForm).WorkingArea.Width - 10 - settingsForm.Width + CurrentScreenOffset.X;
+                settingsForm.Top = Screen.FromControl(settingsForm).WorkingArea.Height - 10 - settingsForm.Height + CurrentScreenOffset.Y;
 
                 settingsForm.Show();
                 settingsForm.Activate();
 
-                settingsForm.Left = Screen.FromControl(settingsForm).WorkingArea.Width - 10 - settingsForm.Width;
-                settingsForm.Top = Screen.FromControl(settingsForm).WorkingArea.Height - 10 - settingsForm.Height;
+                settingsForm.Left = Screen.FromControl(settingsForm).WorkingArea.Width - 10 - settingsForm.Width + CurrentScreenOffset.X;
+                settingsForm.Top = Screen.FromControl(settingsForm).WorkingArea.Height - 10 - settingsForm.Height + CurrentScreenOffset.Y;
 
                 settingsForm.VisualiseGPUMode();
 

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -39,6 +39,8 @@ namespace GHelper
         bool isGpuSection = true;
         bool batteryMouseOver = false;
 
+        string LastScreenName;
+
         public SettingsForm()
         {
 
@@ -200,13 +202,29 @@ namespace GHelper
             buttonFnLock.Click += ButtonFnLock_Click;
 
             panelPerformance.Focus();
+
+            LastScreenName = Screen.FromControl(this).DeviceName;
         }
 
-
-        private void SettingsForm_Resize(object? sender, EventArgs e)
+        private async void SettingsForm_Resize(object? sender, EventArgs e)
         {
-            Left = Screen.FromControl(this).WorkingArea.Width - 10 - Width;
-            Top = Screen.FromControl(this).WorkingArea.Height - 10 - Height;
+            // <dpiAwareness>PerMonitorV2</dpiAwareness> 
+            // Will resize Form for 5 times to find a suitable render size
+            // Relocation must wait for resize actions finished.
+
+            string ScreenName = Screen.FromControl(this).DeviceName;
+            if (ScreenName!= LastScreenName)
+            {
+                Rectangle CurrentScreen = Screen.FromControl(this).WorkingArea;
+                Point CurrentScreenOffset = Screen.FromControl(this).WorkingArea.Location;
+
+                await Task.Delay(500);
+
+                Left = Screen.FromControl(this).WorkingArea.Width - 10 - Width + CurrentScreenOffset.X;
+                Top = Screen.FromControl(this).WorkingArea.Height - 10 - Height + CurrentScreenOffset.Y;
+
+                LastScreenName = ScreenName;
+            }
         }
 
         private void PanelBattery_MouseEnter(object? sender, EventArgs e)

--- a/app/app.manifest
+++ b/app/app.manifest
@@ -54,8 +54,7 @@
 	<application xmlns="urn:schemas-microsoft-com:asm.v3">
 		<windowsSettings>
 			<!--<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor/dpiAwareness>-->
-			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">System</dpiAwareness>
-			<dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+			<dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
 		</windowsSettings>
 	</application>
 


### PR DESCRIPTION
# Blur Fix 
I use `<dpiAwareness>PerMonitorV2</dpiAwareness>` to replace `<dpiAwareness>System</dpiAwareness>` awareness
[https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process](url)

This fix blur text and icon while screens have diffirent DPI (150% for 1st screen, 125% for 2nd screen on my computer) 

Also effect on every sub form. 

### Old 
![Old](https://github.com/seerge/g-helper/assets/35349300/bbca8fe5-7e1a-4edc-a456-5d7547ee6d72)

### New
![New](https://github.com/seerge/g-helper/assets/35349300/35537e71-bde9-46af-b751-496f768a9f1d)

Image is compressed by github. The visual experience is better on native machine.

# Multi Screen Drag Fix

While using `<dpiAwareness>System</dpiAwareness>`, form will not resize when crossing screen.

But under `<dpiAwareness>PerMonitorV2</dpiAwareness>` , DWM will resize form 5 times to find a better render size.

this will trigger `settingForm.Resize()`. Force Form position back to right bottom cornor at initial screen. 

I make Resize() only working on crossing screen. Then relocate form to right bottom cornor of another screen by canculating screen offset.






