### PR TITLE
feat: improve focus behavior

### DIFF
--- a/app/Input/InputDispatcher.cs
+++ b/app/Input/InputDispatcher.cs
@@ -337,7 +337,7 @@ namespace GHelper.Input
             if (e.Modifier == (ModifierKeys.Control | ModifierKeys.Shift))
             {
                 if (e.Key == keyProfile) modeControl.CyclePerformanceMode();
-                if (e.Key == keyApp) Program.SettingsToggle();
+                if (e.Key == keyApp) Program.SettingsToggle("", true);
                 if (e.Key == Keys.F20) KeyProcess("m3");
             }
 
@@ -427,7 +427,7 @@ namespace GHelper.Input
                     {
                         Program.settingsForm.BeginInvoke(delegate
                         {
-                            Program.SettingsToggle();
+                            Program.SettingsToggle("", true);
                         });
                     }
                     catch (Exception ex)

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -213,11 +213,21 @@ namespace GHelper
             SetAutoModes(true);
         }
 
-
-
         public static void SettingsToggle(string action = "")
         {
-            if (settingsForm.Visible) settingsForm.HideAll();
+            if (settingsForm.Visible)
+            {
+                // If helper window is not on top, this just focuses on the app again
+                // Pressing the ghelper button again will hide the app
+                if (!settingsForm.HasAnyFocus())
+                {
+                    settingsForm.ShowAll();
+                }
+                else
+                {
+                    settingsForm.HideAll();
+                }
+            }
             else
             {
 
@@ -279,5 +289,4 @@ namespace GHelper
 
 
     }
-
 }

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -213,13 +213,13 @@ namespace GHelper
             SetAutoModes(true);
         }
 
-        public static void SettingsToggle(string action = "")
+        public static void SettingsToggle(string action = "", bool checkForFocus = false)
         {
             if (settingsForm.Visible)
             {
                 // If helper window is not on top, this just focuses on the app again
                 // Pressing the ghelper button again will hide the app
-                if (!settingsForm.HasAnyFocus())
+                if (checkForFocus && !settingsForm.HasAnyFocus())
                 {
                     settingsForm.ShowAll();
                 }

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -547,6 +547,7 @@ namespace GHelper
             if (matrix == null || matrix.Text == "")
             {
                 matrix = new Matrix();
+                AddOwnedForm(matrix);
             }
 
             if (matrix.Visible)
@@ -615,6 +616,7 @@ namespace GHelper
             {
                 keyb = new Extra();
                 keyb.Show();
+                AddOwnedForm(keyb);
             }
             else
             {
@@ -643,6 +645,7 @@ namespace GHelper
             if (fans == null || fans.Text == "")
             {
                 fans = new Fans();
+                AddOwnedForm(fans);
             }
 
             if (fans.Visible)
@@ -839,6 +842,9 @@ namespace GHelper
             Application.Exit();
         }
 
+        /// <summary>
+        /// Closes all forms except the settings. Hides the settings
+        /// </summary>
         public void HideAll()
         {
             this.Hide();
@@ -849,14 +855,9 @@ namespace GHelper
 
         /// <summary>
         /// Brings all visible windows to the top, with settings being the focus
-        /// <br/>
-        /// Note: this will not respect previous focus i.e. will always focus settings
         /// </summary>
         public void ShowAll()
         {
-            if (fans != null && fans.Visible) fans.Activate();
-            if (keyb != null && keyb.Visible) keyb.Activate();
-            if (updates != null && updates.Visible) updates.Activate();
             this.Activate();
         }
 

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -847,6 +847,27 @@ namespace GHelper
             if (updates != null && updates.Text != "") updates.Close();
         }
 
+        /// <summary>
+        /// Brings all visible windows to the top, with settings being the focus
+        /// <br/>
+        /// Note: this will not respect previous focus i.e. will always focus settings
+        /// </summary>
+        public void ShowAll()
+        {
+            if (fans != null && fans.Visible) fans.Activate();
+            if (keyb != null && keyb.Visible) keyb.Activate();
+            if (updates != null && updates.Visible) updates.Activate();
+            this.Activate();
+        }
+
+        /// <summary>
+        /// Check if any of fans, keyboard, update, or itself has focus
+        /// </summary>
+        /// <returns>Focus state</returns>
+        public bool HasAnyFocus()
+        {
+            return (fans != null && fans.ContainsFocus) || (keyb != null && keyb.ContainsFocus) || (updates != null && updates.ContainsFocus) || this.ContainsFocus;
+        }
 
         private void SettingsForm_FormClosing(object? sender, FormClosingEventArgs e)
         {


### PR DESCRIPTION
Before: when g helper window is out of focus/behind a window, pressing the ROG key will make it disappear, thus making the user have to press twice. Additionally, when clicking the taskbar icon, it only focuses on the settings window. This causes issues when you click other sub panel icons as it hides a non-visible window, confusing the user.

After: pressing ROG key will bring the window to top if it is not in focus. Clicking taskbar icon or activating ROG key will focus all previously visible subpanels to top.