### PR TITLE
Remove unsupported lighting modes for  Keris Wireless Aimpoint

### DIFF
--- a/app/Peripherals/Mouse/Models/KerisWirelssAimpoint.cs
+++ b/app/Peripherals/Mouse/Models/KerisWirelssAimpoint.cs
@@ -66,6 +66,15 @@
             return new LightingZone[] { LightingZone.Logo };
         }
 
+        public override bool IsLightingModeSupported(LightingMode lightingMode)
+        {
+            return lightingMode == LightingMode.Static
+                || lightingMode == LightingMode.Breathing
+                || lightingMode == LightingMode.ColorCycle
+                || lightingMode == LightingMode.BatteryState
+                || lightingMode == LightingMode.React;
+        }
+
         public override bool HasAutoPowerOff()
         {
             return true;


### PR DESCRIPTION
The Keris Wireless Aimpoint does not support all lighting modes. This disables the unsupported ones.