### PR TITLE
added window icon based on GPU mode

### DIFF
--- a/app/Settings.Designer.cs
+++ b/app/Settings.Designer.cs
@@ -1439,7 +1439,6 @@ namespace GHelper
             MinimumSize = new Size(822, 71);
             Name = "SettingsForm";
             Padding = new Padding(11);
-            ShowIcon = false;
             StartPosition = FormStartPosition.CenterScreen;
             Text = "G-Helper";
             panelMatrix.ResumeLayout(false);

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -50,6 +50,22 @@ namespace GHelper
         {
 
             InitializeComponent();
+
+            int GPUMode = AppConfig.Get("gpu_mode");
+
+            switch (GPUMode)
+            {
+                case AsusACPI.GPUModeEco:
+                    this.Icon = Properties.Resources.eco;
+                    break;
+                case AsusACPI.GPUModeUltimate:
+                    this.Icon = Properties.Resources.ultimate;
+                    break;
+                default:
+                    this.Icon = Properties.Resources.standard;
+                    break;
+            }
+
             InitTheme(true);
 
             gpuControl = new GPUModeControl(this);


### PR DESCRIPTION
Since there is no window icon on the top left of the application, it looks a bit ugly when alt tabbing. I have also made it such that the window icon reflects the current GPU mode.