### PR TITLE
fix toggle touchpad

### DIFF
--- a/app/Input/KeyboardHook.cs
+++ b/app/Input/KeyboardHook.cs
@@ -40,10 +40,13 @@ public sealed class KeyboardHook : IDisposable
         keybd_event((byte)key2, 0, KEYEVENTF_EXTENDEDKEY, IntPtr.Zero);
         keybd_event((byte)key3, 0, KEYEVENTF_EXTENDEDKEY, IntPtr.Zero);
 
+        if (sleep > 0)
+        {
+            Thread.Sleep(sleep);
+        }
+
         keybd_event((byte)key3, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, IntPtr.Zero);
-        if (sleep > 0) Thread.Sleep(sleep);
         keybd_event((byte)key2, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, IntPtr.Zero);
-        if (sleep > 0) Thread.Sleep(sleep);
         keybd_event((byte)key, 0, KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, IntPtr.Zero);
     }
 


### PR DESCRIPTION
After v0.131 update i noticed that FN+F10 doesn't toggle touchpad state at all, in the discussion [#1504](https://github.com/seerge/g-helper/discussions/1504) i meant to add delay before firing all key up events, now it works as it should, even with 50ms delay