### PR TITLE
setting different icon for taskbar and title bar

### DIFF
--- a/app/Settings.Designer.cs
+++ b/app/Settings.Designer.cs
@@ -1439,7 +1439,7 @@ namespace GHelper
             MinimumSize = new Size(822, 71);
             Name = "SettingsForm";
             Padding = new Padding(11);
-            ShowIcon = false;
+            ShowIcon = true;
             StartPosition = FormStartPosition.CenterScreen;
             Text = "G-Helper";
             panelMatrix.ResumeLayout(false);

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -1164,6 +1164,9 @@ namespace GHelper
             ButtonEnabled(buttonStandard, true);
             ButtonEnabled(buttonUltimate, true);
 
+            Bitmap? smallBmp = null;
+            Bitmap? bigBmp = null;
+
             if (GPUMode == -1)
                 GPUMode = AppConfig.Get("gpu_mode");
 
@@ -1183,8 +1186,8 @@ namespace GHelper
                     labelGPU.Text = Properties.Strings.GPUMode + ": " + Properties.Strings.GPUModeEco;
                     Program.trayIcon.Icon = Properties.Resources.eco;
 
-                    Bitmap smallBmp = Properties.Resources.dot_eco.ToBitmap();
-                    Bitmap bigBmp = Properties.Resources.eco.ToBitmap();
+                    smallBmp = Properties.Resources.dot_eco.ToBitmap();
+                    bigBmp = Properties.Resources.eco.ToBitmap();
 
                     SendMessage(this.Handle, WM_SETICON, ICON_SMALL, smallBmp.GetHicon());
                     SendMessage(this.Handle, WM_SETICON, ICON_BIG, bigBmp.GetHicon());
@@ -1194,8 +1197,8 @@ namespace GHelper
                     labelGPU.Text = Properties.Strings.GPUMode + ": " + Properties.Strings.GPUModeUltimate;
                     Program.trayIcon.Icon = Properties.Resources.ultimate;
 
-                    Bitmap smallBmp = Properties.Resources.dot_ultimate.ToBitmap();
-                    Bitmap bigBmp = Properties.Resources.ultimate.ToBitmap();
+                    smallBmp = Properties.Resources.dot_ultimate.ToBitmap();
+                    bigBmp = Properties.Resources.ultimate.ToBitmap();
 
                     SendMessage(this.Handle, WM_SETICON, ICON_SMALL, smallBmp.GetHicon());
                     SendMessage(this.Handle, WM_SETICON, ICON_BIG, bigBmp.GetHicon());
@@ -1207,8 +1210,8 @@ namespace GHelper
                     labelGPU.Text = Properties.Strings.GPUMode + ": " + Properties.Strings.GPUModeStandard;
                     Program.trayIcon.Icon = Properties.Resources.standard;
 
-                    Bitmap smallBmp = Properties.Resources.dot_standard.ToBitmap();
-                    Bitmap bigBmp = Properties.Resources.standard.ToBitmap();
+                    smallBmp = Properties.Resources.dot_standard.ToBitmap();
+                    bigBmp = Properties.Resources.standard.ToBitmap();
 
                     SendMessage(this.Handle, WM_SETICON, ICON_SMALL, smallBmp.GetHicon());
                     SendMessage(this.Handle, WM_SETICON, ICON_BIG, bigBmp.GetHicon());

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -13,13 +13,12 @@ using GHelper.UI;
 using GHelper.USB;
 using System.Diagnostics;
 using System.Timers;
+using System.Runtime.InteropServices;
 
 namespace GHelper
 {
-
     public partial class SettingsForm : RForm
     {
-
         ContextMenuStrip contextMenuStrip = new CustomContextMenu();
         ToolStripMenuItem menuSilent, menuBalanced, menuTurbo, menuEco, menuStandard, menuUltimate, menuOptimized;
 
@@ -1151,6 +1150,12 @@ namespace GHelper
             });
         }
 
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        private static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+
+        private const uint WM_SETICON = 0x80u;
+        private const int ICON_SMALL = 0;
+        private const int ICON_BIG = 1;
 
         public void VisualiseGPUMode(int GPUMode = -1)
         {
@@ -1177,13 +1182,23 @@ namespace GHelper
                     buttonOptimized.Activated = GPUAuto;
                     labelGPU.Text = Properties.Strings.GPUMode + ": " + Properties.Strings.GPUModeEco;
                     Program.trayIcon.Icon = Properties.Resources.eco;
-                    Icon = Properties.Resources.dot_eco;
+
+                    Bitmap smallBmp = Properties.Resources.dot_eco.ToBitmap();
+                    Bitmap bigBmp = Properties.Resources.eco.ToBitmap();
+
+                    SendMessage(this.Handle, WM_SETICON, ICON_SMALL, smallBmp.GetHicon());
+                    SendMessage(this.Handle, WM_SETICON, ICON_BIG, bigBmp.GetHicon());
                     break;
                 case AsusACPI.GPUModeUltimate:
                     buttonUltimate.Activated = true;
                     labelGPU.Text = Properties.Strings.GPUMode + ": " + Properties.Strings.GPUModeUltimate;
                     Program.trayIcon.Icon = Properties.Resources.ultimate;
-                    Icon = Properties.Resources.dot_ultimate;
+
+                    Bitmap smallBmp = Properties.Resources.dot_ultimate.ToBitmap();
+                    Bitmap bigBmp = Properties.Resources.ultimate.ToBitmap();
+
+                    SendMessage(this.Handle, WM_SETICON, ICON_SMALL, smallBmp.GetHicon());
+                    SendMessage(this.Handle, WM_SETICON, ICON_BIG, bigBmp.GetHicon());
                     break;
                 default:
                     buttonOptimized.BorderColor = colorStandard;
@@ -1191,7 +1206,12 @@ namespace GHelper
                     buttonOptimized.Activated = GPUAuto;
                     labelGPU.Text = Properties.Strings.GPUMode + ": " + Properties.Strings.GPUModeStandard;
                     Program.trayIcon.Icon = Properties.Resources.standard;
-                    Icon = Properties.Resources.dot_standard;
+
+                    Bitmap smallBmp = Properties.Resources.dot_standard.ToBitmap();
+                    Bitmap bigBmp = Properties.Resources.standard.ToBitmap();
+
+                    SendMessage(this.Handle, WM_SETICON, ICON_SMALL, smallBmp.GetHicon());
+                    SendMessage(this.Handle, WM_SETICON, ICON_BIG, bigBmp.GetHicon());
                     break;
             }
 


### PR DESCRIPTION
Setting the title bar icon and taskbar icon separately using SendMessage.
fixes #1604 

Should smallBmp and bigBmp be disposed after passing the handle to SendMessage (which was done using [GetHicon()](https://learn.microsoft.com/en-us/dotnet/api/system.drawing.bitmap.gethicon?view=dotnet-plat-ext-7.0))? Or should it instead just be a oneliner like `Properties.Resources.ultimate.ToBitmap().GetHicon()` ?

SO Solution Link: https://stackoverflow.com/questions/4048910/setting-a-different-taskbar-icon-to-the-icon-displayed-in-the-titlebar-c