### PR TITLE
Remove delay when main window opens

### DIFF
--- a/app/Program.cs
+++ b/app/Program.cs
@@ -122,6 +122,8 @@ namespace GHelper
                 SettingsToggle(action, false);
             }
 
+            Startup.StartupCheck();
+            
             Application.Run();
 
         }
@@ -264,9 +266,6 @@ namespace GHelper
                         Startup.ReScheduleAdmin();
                         settingsForm.FansToggle(2);
                         modeControl.SetRyzen();
-                        break;
-                    default:
-                        Startup.StartupCheck();
                         break;
                 }
             }


### PR DESCRIPTION
Calling `Startup.StartupCheck()` method may result to ~0.5-2 seconds delay before application window loads and becomes responsive. It depends on how many windows services are running and lag may happen on this line `var task = taskService.RootFolder.AllTasks.FirstOrDefault(t => t.Name == taskName);.` Sometimes it executes faster sometimes very slow.
I don't think we need to check task path on every window opening. If application was updated or moved then it should be enough to check task's exe path once on startup.