### PR TITLE
Polling rate fix for Keris Wireless Aimpoint

### DIFF
--- a/app/Peripherals/Mouse/Models/KerisWirelssAimpoint.cs
+++ b/app/Peripherals/Mouse/Models/KerisWirelssAimpoint.cs
@@ -99,6 +99,18 @@
         {
             return true;
         }
+        // 3.00.06 - 4.00.01 or newer firmware
+        protected override PollingRate ParsePollingRate(byte[] packet)
+        {
+            if (packet[1] == 0x12 && packet[2] == 0x04 && packet[3] == 0x00)
+            {
+                if ((int)packet[13] > 7)
+                    return (PollingRate)packet[13] - 96;
+                return (PollingRate)packet[13];
+            }
+
+            return PollingRate.PR125Hz;
+        }
     }
 
     public class KerisWirelssAimpointWired : KerisWirelssAimpoint


### PR DESCRIPTION
On newest firmware (April 2024), on packet 13, instead start from 0 for polling rate values, they bump it to 96. I have a check for someone that use the old firmware, tested on the new one but maybe wait for someone with old firmware check it.