### PR TITLE
Battery Percentage Pattern for Slash Lighting

### DIFF
--- a/app/AnimeMatrix/AniMatrixControl.cs
+++ b/app/AnimeMatrix/AniMatrixControl.cs
@@ -117,7 +117,7 @@ namespace GHelper.AnimeMatrix
                             }
                             break;
                         case SlashMode.BatteryLevel:
-                            SlashTimer_start(1000);
+                            SlashTimer_start();
                             break;
                         default:
                             deviceSlash.SetMode((SlashMode)running);
@@ -270,12 +270,12 @@ namespace GHelper.AnimeMatrix
         }
         
         
-        private void SlashTimer_start(int interval = 100000)
+        private void SlashTimer_start(int interval = 60000)
         {
             // 100% to 0% in 1hr = 1% every 36 seconds
             // 1 bracket every 14.2857 * 36s = 514s ~ 8m 30s
             // only ~5 actually distinguishable levels, so refresh every <= 514/5 ~ 100s
-            // default is 100s = 100000ms
+            // default is 60s
 
             // create the timer if first call
             // this way, the timer only spawns if user tries to use battery pattern

--- a/app/AnimeMatrix/AniMatrixControl.cs
+++ b/app/AnimeMatrix/AniMatrixControl.cs
@@ -117,7 +117,9 @@ namespace GHelper.AnimeMatrix
                             }
                             break;
                         case SlashMode.BatteryLevel:
+                            // call tick to immediately update the pattern
                             SlashTimer_start();
+                            SlashTimer_tick();
                             break;
                         default:
                             deviceSlash.SetMode((SlashMode)running);
@@ -243,8 +245,6 @@ namespace GHelper.AnimeMatrix
             matrixTimer.Stop();
         }
 
-
-
         private void MatrixTimer_Elapsed(object? sender, ElapsedEventArgs e)
         {
 
@@ -295,6 +295,11 @@ namespace GHelper.AnimeMatrix
         }
 
         private void SlashTimer_elapsed(object? sender, ElapsedEventArgs e)
+        {
+            SlashTimer_tick();
+        }
+
+        private void SlashTimer_tick()
         {
             if (deviceSlash is null) return;
 

--- a/app/AnimeMatrix/AniMatrixControl.cs
+++ b/app/AnimeMatrix/AniMatrixControl.cs
@@ -311,7 +311,7 @@ namespace GHelper.AnimeMatrix
                 return;
             }
 
-            deviceSlash.setBatteryPattern(AppConfig.Get("matrix_brightness", 0));
+            deviceSlash.SetBatteryPattern(AppConfig.Get("matrix_brightness", 0));
         }
 
 

--- a/app/AnimeMatrix/AniMatrixControl.cs
+++ b/app/AnimeMatrix/AniMatrixControl.cs
@@ -114,6 +114,15 @@ namespace GHelper.AnimeMatrix
                                 deviceSlash.SetStatic(brightness);
                             }
                             break;
+                        case SlashMode.BatteryLevel:
+                            deviceSlash.setBatteryPattern(brightness, 50);
+                            // because battery discharges slowly, lower refresh rate:
+                            // 100% in 1hr = 1% every 36 seconds
+                            // 1 bracket every 14.2857% * 36s = 514.2852s
+                            // 1 brightness level every 514.2852s / 3 = 171.4284 seconds
+                            // so even at once per minute, it's still faster than peak battery discharging
+                            deviceSlash.SetOptions(true, brightness, 60000);
+                            break;
                         default:
                             deviceSlash.SetMode((SlashMode)running);
                             deviceSlash.SetOptions(true, brightness, inteval);

--- a/app/AnimeMatrix/SlashDevice.cs
+++ b/app/AnimeMatrix/SlashDevice.cs
@@ -153,7 +153,7 @@ namespace GHelper.AnimeMatrix
                 return batteryCharge;
             }
 
-        private byte[] getBatteryPattern(int brightness, double percentage)
+        private byte[] GetBatteryPattern(int brightness, double percentage)
         {
             // because 7 segments, within each led segment represents a percentage bracket of (100/7 = 14.2857%)
             // set brightness to reflect battery's percentage within that range
@@ -173,19 +173,9 @@ namespace GHelper.AnimeMatrix
             return batteryPattern;
         }
 
-        private static int testing = 0;
-        public void setBatteryPattern(int brightness)
+        public void SetBatteryPattern(int brightness)
         {
-            // if(testing == 3){
-            //     SetCustom(new byte[] {0x00, 0xff, 0x00, 0xff, 0x00, 0xff, 0x00});
-            //     testing = 0;
-            // }
-            // else{
-            //     testing++;
-            //     SetCustom(getBatteryPattern(brightness, 100*(GetBatteryChargePercentage()/AppConfig.Get("charge_limit",100))));
-            // }
-            
-            SetCustom(getBatteryPattern(brightness, 100*(GetBatteryChargePercentage()/AppConfig.Get("charge_limit",100))));
+            SetCustom(GetBatteryPattern(brightness, 100*(GetBatteryChargePercentage()/AppConfig.Get("charge_limit",100))));
         }
 
         public void SetCustom(byte[] data)


### PR DESCRIPTION
Added a new slash lighting pattern that reflects the current charge status of the machine. It respects the user's requested brightness level (dim, medium, bright) and sets the user's charge limit as 100% / full charge. 

Because the slash lighting is simply a string of bytes with no sense of memory of what set them, this pattern requires updating. TO accomplish this, a new timer was added that:
- only spawns when the user selects the battery pattern
- only refreshes the pattern every minute
- disposes of itself if somehow still running on a different pattern