### PR TITLE
Restore the miniled setting on reboot.

### DIFF
--- a/app/Display/ScreenControl.cs
+++ b/app/Display/ScreenControl.cs
@@ -10,17 +10,27 @@ namespace GHelper.Display
 
         public void AutoScreen(bool force = false)
         {
+            int frequency = -1;
+            int overdrive = -1;
             if (force || AppConfig.Is("screen_auto"))
             {
                 if (SystemInformation.PowerStatus.PowerLineStatus == PowerLineStatus.Online)
-                    SetScreen(MAX_REFRESH, 1);
+                {
+                    frequency = MAX_REFRESH;
+                    overdrive = 1;
+                }
                 else
-                    SetScreen(60, 0);
+                {
+                    frequency = 60;
+                    overdrive = 0;
+                }
             }
             else
             {
-                SetScreen(overdrive: AppConfig.Get("overdrive"));
+                overdrive = AppConfig.Get("overdrive");
             }
+
+            SetScreen(frequency, overdrive, AppConfig.Get("miniled"));
         }
 
         public void ToggleScreenRate()

--- a/app/Display/ScreenControl.cs
+++ b/app/Display/ScreenControl.cs
@@ -12,6 +12,7 @@ namespace GHelper.Display
         {
             int frequency = -1;
             int overdrive = -1;
+            int miniled = -1;
             if (force || AppConfig.Is("screen_auto"))
             {
                 if (SystemInformation.PowerStatus.PowerLineStatus == PowerLineStatus.Online)
@@ -30,7 +31,12 @@ namespace GHelper.Display
                 overdrive = AppConfig.Get("overdrive");
             }
 
-            SetScreen(frequency, overdrive, AppConfig.Get("miniled"));
+            if (AppConfig.Is("aggressively_set_miniled"))
+            {
+                miniled = AppConfig.Get("miniled");
+            }
+
+            SetScreen(frequency, overdrive, miniled);
         }
 
         public void ToggleScreenRate()

--- a/app/Extra.Designer.cs
+++ b/app/Extra.Designer.cs
@@ -143,6 +143,7 @@ namespace GHelper
             checkBatteryLid = new CheckBox();
             checkBattery = new CheckBox();
             checkBatteryLogo = new CheckBox();
+            checkAggressiveMiniLed = new CheckBox();
             panelServices.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)pictureService).BeginInit();
             panelBindingsHeader.SuspendLayout();
@@ -1141,6 +1142,7 @@ namespace GHelper
             panelSettings.AccessibleRole = AccessibleRole.Grouping;
             panelSettings.AutoSize = true;
             panelSettings.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            panelSettings.Controls.Add(checkAggressiveMiniLed);
             panelSettings.Controls.Add(checkAutoToggleClamshellMode);
             panelSettings.Controls.Add(checkBWIcon);
             panelSettings.Controls.Add(checkTopmost);
@@ -1302,6 +1304,18 @@ namespace GHelper
             checkPerKeyRGB.Text = "Per-Key RGB Keyboard";
             checkPerKeyRGB.UseVisualStyleBackColor = true;
             checkPerKeyRGB.Visible = false;
+            // checkAggressiveMiniLed
+            // 
+            checkAggressiveMiniLed.AutoSize = true;
+            checkAggressiveMiniLed.Dock = DockStyle.Top;
+            checkAggressiveMiniLed.Location = new Point(10, 255);
+            checkAggressiveMiniLed.Margin = new Padding(4, 3, 4, 3);
+            checkAggressiveMiniLed.Name = "checkAggressiveMiniLed";
+            checkAggressiveMiniLed.Padding = new Padding(3);
+            checkAggressiveMiniLed.Size = new Size(550, 23);
+            checkAggressiveMiniLed.TabIndex = 14;
+            checkAggressiveMiniLed.Text = Strings.AggressivelyReapplyMiniLed;
+            checkAggressiveMiniLed.UseVisualStyleBackColor = true;
             // 
             // panelPower
             // 
@@ -1792,5 +1806,6 @@ namespace GHelper
         private CheckBox checkBattery;
         private CheckBox checkBatteryLid;
         private CheckBox checkBatteryBar;
+        private CheckBox checkAggressiveMiniLed;
     }
 }

--- a/app/Extra.cs
+++ b/app/Extra.cs
@@ -439,6 +439,7 @@ namespace GHelper
             checkPerKeyRGB.Checked = AppConfig.Is("per_key_rgb");
             checkPerKeyRGB.CheckedChanged += CheckPerKeyRGB_CheckedChanged;
 
+            checkAggressiveMiniLed.Checked = AppConfig.Is("aggressively_set_miniled");
             checkAggressiveMiniLed.CheckedChanged += CheckAggressiveMiniLed_CheckedChanged;
 
             toolTip.SetToolTip(checkAutoToggleClamshellMode, "Disable sleep on lid close when plugged in and external monitor is connected");

--- a/app/Extra.cs
+++ b/app/Extra.cs
@@ -439,6 +439,8 @@ namespace GHelper
             checkPerKeyRGB.Checked = AppConfig.Is("per_key_rgb");
             checkPerKeyRGB.CheckedChanged += CheckPerKeyRGB_CheckedChanged;
 
+            checkAggressiveMiniLed.CheckedChanged += CheckAggressiveMiniLed_CheckedChanged;
+
             toolTip.SetToolTip(checkAutoToggleClamshellMode, "Disable sleep on lid close when plugged in and external monitor is connected");
 
             InitCores();
@@ -448,6 +450,11 @@ namespace GHelper
 
             InitACPITesting();
 
+        }
+
+        private void CheckAggressiveMiniLed_CheckedChanged(object? sender, EventArgs e)
+        {
+            AppConfig.Set("aggressively_set_miniled", (checkAggressiveMiniLed.Checked ? 1 : 0));
         }
 
         private void CheckPerKeyRGB_CheckedChanged(object? sender, EventArgs e)

--- a/app/NativeMethods.cs
+++ b/app/NativeMethods.cs
@@ -65,6 +65,7 @@ public class NativeMethods
     internal const uint DEVICE_NOTIFY_WINDOW_HANDLE = 0x0;
     internal const uint DEVICE_NOTIFY_SERVICE_HANDLE = 0x1;
     internal const int WM_POWERBROADCAST = 0x0218;
+    internal const int WM_DISPLAYCHANGE = 0x7E;
     internal const int PBT_POWERSETTINGCHANGE = 0x8013;
 
     [DllImport("User32.dll", SetLastError = true)]

--- a/app/Properties/Strings.Designer.cs
+++ b/app/Properties/Strings.Designer.cs
@@ -79,6 +79,15 @@ namespace GHelper.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Aggressively reapply MiniLed.
+        /// </summary>
+        internal static string AggressivelyReapplyMiniLed {
+            get {
+                return ResourceManager.GetString("AggressivelyReapplyMiniLed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Restart your device to apply changes.
         /// </summary>
         internal static string AlertAPUMemoryRestart {
@@ -1575,7 +1584,7 @@ namespace GHelper.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Switch to Eco on battery and to Standard when plugged.
+        ///   Looks up a localized string similar to Switch to Eco on battery and to Standard when plugged in.
         /// </summary>
         internal static string OptimizedGPUTooltip {
             get {

--- a/app/Properties/Strings.resx
+++ b/app/Properties/Strings.resx
@@ -800,4 +800,7 @@ Do you still want to continue?</value>
   <data name="Zoom" xml:space="preserve">
     <value>Zoom</value>
   </data>
+  <data name="AggressivelyReapplyMiniLed" xml:space="preserve">
+    <value>Aggressively reapply MiniLed</value>
+  </data>
 </root>

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -683,6 +683,11 @@ namespace GHelper
                 }
                 m.Result = (IntPtr)1;
             }
+            else if (m.Msg == NativeMethods.WM_DISPLAYCHANGE)
+            {
+                Logger.WriteLine("Display Changed");
+                screenControl.AutoScreen();
+            }
 
             try
             {


### PR DESCRIPTION
Fixes #2802

Appears to workaround firmware bug as described in https://github.com/seerge/g-helper/issues/2802