### PR TITLE
Remove unnecessary overrides from M4 Air

### DIFF
--- a/app/Peripherals/Mouse/Models/TUFM4Air.cs
+++ b/app/Peripherals/Mouse/Models/TUFM4Air.cs
@@ -42,11 +42,6 @@
             return true;
         }
 
-        public override bool HasDebounceSetting()
-        {
-            return true;
-        }
-
         public override bool HasAngleSnapping()
         {
             return true;
@@ -62,19 +57,9 @@
             return false;
         }
 
-        public override bool HasDPIColors()
-        {
-            return false;
-        }
-
         public override int DPIIncrements()
         {
             return 100;
-        }
-
-        public override bool CanChangeDPIProfile()
-        {
-            return true;
         }
     }
 


### PR DESCRIPTION
Remove unnecessary overrides from M4 Air

This is just a clean-up as it overrides functions with identical implementations which is not necessary and just adds clutter.