### PR TITLE
Custom fan curves in tray icon menu

### DIFF
--- a/app/Fans.cs
+++ b/app/Fans.cs
@@ -497,6 +497,7 @@ namespace GHelper
             comboModes.DataSource = new BindingSource(Modes.GetDictonary(), null);
             comboModes.DisplayMember = "Value";
             comboModes.ValueMember = "Key";
+            Program.settingsForm.SetContextMenu();
         }
 
         private void ButtonAdd_Click(object? sender, EventArgs e)

--- a/app/Mode/Modes.cs
+++ b/app/Mode/Modes.cs
@@ -21,6 +21,18 @@
 
             return modes;
         }
+        
+        public static Dictionary<int, string> GetDictionaryCustom()
+        {
+            Dictionary<int, string> modes = new Dictionary<int, string>();
+
+            for (int i = 3; i < maxModes; i++)
+            {
+                if (Exists(i)) modes.Add(i, GetName(i));
+            }
+
+            return modes;
+        }
 
         public static List<int> GetList()
         {

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -21,6 +21,8 @@ namespace GHelper
     {
         ContextMenuStrip contextMenuStrip = new CustomContextMenu();
         ToolStripMenuItem menuSilent, menuBalanced, menuTurbo, menuEco, menuStandard, menuUltimate, menuOptimized;
+        Dictionary<int, ToolStripMenuItem> menuModesCustom = new ();
+
 
         public GPUModeControl gpuControl;
         public AllyControl allyControl;
@@ -732,6 +734,19 @@ namespace GHelper
             menuTurbo.Checked = (mode == AsusACPI.PerformanceTurbo);
             contextMenuStrip.Items.Add(menuTurbo);
 
+            if (Modes.GetDictionaryCustom().Count > 0)
+                contextMenuStrip.Items.Add("-");
+
+            foreach (var (modeIdx, name) in Modes.GetDictionaryCustom())
+            {
+                var menuCustom = new ToolStripMenuItem(name);
+                menuCustom.Click += (sender, args) => { Program.modeControl.SetPerformanceMode(modeIdx); };
+                menuCustom.Margin = padding;
+                menuCustom.Checked = (modeIdx == Modes.GetCurrent());
+                menuModesCustom.Add(modeIdx, menuCustom);
+                contextMenuStrip.Items.Add(menuCustom);
+            }
+            
             contextMenuStrip.Items.Add("-");
 
             if (isGpuSection)
@@ -1474,6 +1489,10 @@ namespace GHelper
             menuSilent.Checked = false;
             menuBalanced.Checked = false;
             menuTurbo.Checked = false;
+            foreach (var (key, value) in menuModesCustom)
+            {
+                value.Checked = false;
+            }
 
             switch (mode)
             {
@@ -1490,6 +1509,8 @@ namespace GHelper
                     menuBalanced.Checked = true;
                     break;
                 default:
+                    if (menuModesCustom.TryGetValue(mode, out var value))
+                        value.Checked = true;
                     buttonFans.Activated = true;
                     buttonFans.BorderColor = Modes.GetBase(mode) switch
                     {

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -737,6 +737,7 @@ namespace GHelper
             if (Modes.GetDictionaryCustom().Count > 0)
                 contextMenuStrip.Items.Add("-");
 
+            menuModesCustom.Clear();
             foreach (var (modeIdx, name) in Modes.GetDictionaryCustom())
             {
                 var menuCustom = new ToolStripMenuItem(name);


### PR DESCRIPTION
This is WIP pr to add custom fan curves to the tray icon context menu
![image](https://github.com/user-attachments/assets/b334a784-457b-4f2d-b72a-0a3d1a6b76d2)

Currently, adding/removing fan curve doesn't update menu
