### PR TITLE
Add tooltip and message to specify seconds in keyboard light timeout

### DIFF
--- a/app/Extra.cs
+++ b/app/Extra.cs
@@ -172,7 +172,9 @@ namespace GHelper
             comboFNE.AccessibleName = "Fn+Numpad Action";
 
             numericBacklightPluggedTime.AccessibleName = Properties.Strings.BacklightTimeoutPlugged;
+            toolTip.SetToolTip(numericBacklightPluggedTime, Properties.Strings.BacklightTimeoutPlugged);
             numericBacklightTime.AccessibleName = Properties.Strings.BacklightTimeoutBattery;
+            toolTip.SetToolTip(numericBacklightTime, Properties.Strings.BacklightTimeoutBattery);
 
             comboKeyboardSpeed.AccessibleName = Properties.Strings.LaptopBacklight + " " +Properties.Strings.AnimationSpeed;
             comboAPU.AccessibleName = Properties.Strings.LaptopBacklight + " " + Properties.Strings.AnimationSpeed;

--- a/app/Properties/Strings.Designer.cs
+++ b/app/Properties/Strings.Designer.cs
@@ -493,7 +493,7 @@ namespace GHelper.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Timeout plugged / on battery (0 - ON).
+        ///   Looks up a localized string similar to Timeout plugged / on battery (0 - ON) [seconds].
         /// </summary>
         internal static string BacklightTimeout {
             get {
@@ -1575,7 +1575,7 @@ namespace GHelper.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Switch to Eco on battery and to Standard when plugged.
+        ///   Looks up a localized string similar to Switch to Eco on battery and to Standard when plugged in.
         /// </summary>
         internal static string OptimizedGPUTooltip {
             get {

--- a/app/Properties/Strings.da.resx
+++ b/app/Properties/Strings.da.resx
@@ -262,7 +262,7 @@
     <value>Slukket</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Timeout tilsluttet / på batteri (0 - TIL)</value>
+    <value>Timeout tilsluttet / på batteri (0 - TIL) [sekunder]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Baggrundslys timeout på batteri</value>

--- a/app/Properties/Strings.de.resx
+++ b/app/Properties/Strings.de.resx
@@ -262,7 +262,7 @@
     <value>Aus</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Timeout angeschlossen / bei Akku (0 = An)</value>
+    <value>Timeout angeschlossen / bei Akku (0 = An) [Sekunden]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Backlight Timeout when on battery</value>

--- a/app/Properties/Strings.es.resx
+++ b/app/Properties/Strings.es.resx
@@ -262,7 +262,7 @@
     <value>Apagado</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Tiempo de espera conectado / con batería (0 - ON)</value>
+    <value>Tiempo de espera conectado / con batería (0 - ON) [segundos]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Tiempo de retroiluminación con batería</value>

--- a/app/Properties/Strings.fr.resx
+++ b/app/Properties/Strings.fr.resx
@@ -262,7 +262,7 @@
     <value>Désactivé</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Délai branché / sur batterie (0 - ON)</value>
+    <value>Délai branché / sur batterie (0 - ON) [secondes]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Délai de rétro-éclairage sur batterie</value>

--- a/app/Properties/Strings.hu.resx
+++ b/app/Properties/Strings.hu.resx
@@ -262,7 +262,7 @@
     <value>Off</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Késleltetés töltés / akku módban (0 - BE)</value>
+    <value>Késleltetés töltés / akku módban (0 - BE) [másodperc]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Backlight Timeout when on battery</value>

--- a/app/Properties/Strings.id.resx
+++ b/app/Properties/Strings.id.resx
@@ -262,7 +262,7 @@
     <value>Mati</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Waktu tunggu dicolokan / menggunakan baterai (0 - Hidup)</value>
+    <value>Waktu tunggu dicolokan / menggunakan baterai (0 - Hidup) [detik]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Backlight Timeout when on battery</value>

--- a/app/Properties/Strings.it.resx
+++ b/app/Properties/Strings.it.resx
@@ -262,7 +262,7 @@
     <value>Off</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Timeout in carica / a batteria (0 - ACCESO)</value>
+    <value>Timeout in carica / a batteria (0 - ACCESO) [secondi]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Backlight Timeout when on battery</value>

--- a/app/Properties/Strings.ja.resx
+++ b/app/Properties/Strings.ja.resx
@@ -262,7 +262,7 @@
     <value>Off</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Timeout plugged / on battery (0 - ON)</value>
+    <value>Timeout plugged / on battery (0 - ON) [seconds]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Backlight Timeout when on battery</value>

--- a/app/Properties/Strings.ko.resx
+++ b/app/Properties/Strings.ko.resx
@@ -262,7 +262,7 @@
     <value>꺼짐</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>전원 / 배터리 사용 중 자동 꺼짐 시간 (0 - 항상 켜짐)</value>
+    <value>전원 / 배터리 사용 중 자동 꺼짐 시간 (0 - 항상 켜짐) [초]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>배터리 사용 중 백라이트 자동 꺼짐</value>

--- a/app/Properties/Strings.lt.resx
+++ b/app/Properties/Strings.lt.resx
@@ -262,7 +262,7 @@
     <value>Išjungta</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Laiko riba su lizdu / akumuliatoriumi (0 – ĮJUNGTA)</value>
+    <value>Laiko riba su lizdu / akumuliatoriumi (0 – ĮJUNGTA)[sekundės]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Backlight Timeout when on battery</value>

--- a/app/Properties/Strings.pl.resx
+++ b/app/Properties/Strings.pl.resx
@@ -262,7 +262,7 @@
     <value>Wyłączone</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Limit czasu podłączonego / na baterii (0 - Włączony)</value>
+    <value>Limit czasu podłączonego / na baterii (0 - Włączony) [sekundy]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Czas podświetlenia na baterii</value>

--- a/app/Properties/Strings.pt-BR.resx
+++ b/app/Properties/Strings.pt-BR.resx
@@ -262,7 +262,7 @@
     <value>Off</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Tempo limite plugado / na bateria (0 - ligado)</value>
+    <value>Tempo limite plugado / na bateria (0 - ligado) [segundos]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Backlight Timeout when on battery</value>

--- a/app/Properties/Strings.pt-PT.resx
+++ b/app/Properties/Strings.pt-PT.resx
@@ -262,7 +262,7 @@
     <value>Off</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Tempo limite ligado à corrente / na bateria (0 - ON)</value>
+    <value>Tempo limite ligado à corrente / na bateria (0 - ON) [segundos]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Desligar o ecrã após (em Bateria)</value>

--- a/app/Properties/Strings.resx
+++ b/app/Properties/Strings.resx
@@ -262,7 +262,7 @@
     <value>Off</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Timeout plugged / on battery (0 - ON)</value>
+    <value>Timeout plugged / on battery (0 - ON) [seconds]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Backlight Timeout when on battery</value>

--- a/app/Properties/Strings.ro.resx
+++ b/app/Properties/Strings.ro.resx
@@ -262,7 +262,7 @@
     <value>Off</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Timeout conectat / folosind bateria (0 - ON)</value>
+    <value>Timeout conectat / folosind bateria (0 - ON) [secunde]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Timp oprire iluminare pe baterie</value>

--- a/app/Properties/Strings.tr.resx
+++ b/app/Properties/Strings.tr.resx
@@ -262,7 +262,7 @@
     <value>Kapalı</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Pilde klavye ışığı kapanma süresi</value>
+    <value>Pilde klavye ışığı kapanma süresi [saniye]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Pildeyken Arka Işık Zaman Aşımı</value>

--- a/app/Properties/Strings.uk.resx
+++ b/app/Properties/Strings.uk.resx
@@ -262,7 +262,7 @@
     <value>Вимкнена</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Тайм-аут на зарядці / на батареї (0 - УВІМК)</value>
+    <value>Тайм-аут на зарядці / на батареї (0 - УВІМК) [секунди]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Тайм-аут підсвітки на батареї</value>

--- a/app/Properties/Strings.vi.resx
+++ b/app/Properties/Strings.vi.resx
@@ -262,7 +262,7 @@
     <value>Off</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>Số giây để tắt đèn nền bàn phím(khi dùng pin)</value>
+    <value>Số giây để tắt đèn nền bàn phím(khi dùng pin) [giây]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>Backlight Timeout when on battery</value>

--- a/app/Properties/Strings.zh-CN.resx
+++ b/app/Properties/Strings.zh-CN.resx
@@ -262,7 +262,7 @@
     <value>背光关闭</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>插电/电池时熄灭时间（0表示长亮）</value>
+    <value>插电/电池时熄灭时间（0表示长亮）[秒]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>充电模式下的背光超时</value>

--- a/app/Properties/Strings.zh-TW.resx
+++ b/app/Properties/Strings.zh-TW.resx
@@ -262,7 +262,7 @@
     <value>關閉</value>
   </data>
   <data name="BacklightTimeout" xml:space="preserve">
-    <value>閒置幾秒後關閉燈光：插電時 / 使用電池 (0 = 不關閉)</value>
+    <value>閒置幾秒後關閉燈光：插電時 / 使用電池 (0 = 不關閉) [秒]</value>
   </data>
   <data name="BacklightTimeoutBattery" xml:space="preserve">
     <value>閒置時關閉燈光(電池模式)</value>


### PR DESCRIPTION
Hi,

I've had a hard time trying to figure out what the input boxes do as well as trying to understand what units the numbers represent. 
This is a small change to alleviate that. 