### PR TITLE
IsOLED: Add Zenbook S 14 (Intel), Zenbook S 16 (AMD)

### DIFF
--- a/app/AppConfig.cs
+++ b/app/AppConfig.cs
@@ -454,7 +454,7 @@ public static class AppConfig
 
     public static bool IsOLED()
     {
-        return ContainsModel("OLED") || IsSlash() || ContainsModel("M7600") || ContainsModel("UX64") || ContainsModel("UX34") || ContainsModel("UX53") || ContainsModel("K360") || ContainsModel("X150") || ContainsModel("M350") || ContainsModel("K650") || ContainsModel("UM53") || ContainsModel("K660") || ContainsModel("UX84") || ContainsModel("M650") || ContainsModel("M550") || ContainsModel("K340") || ContainsModel("K350") || ContainsModel("M140") || ContainsModel("UM340") || ContainsModel("S540") || ContainsModel("M7400") || ContainsModel("N650") || ContainsModel("HN7306") || ContainsModel("H7606");
+        return ContainsModel("OLED") || IsSlash() || ContainsModel("M7600") || ContainsModel("UX64") || ContainsModel("UX34") || ContainsModel("UX53") || ContainsModel("K360") || ContainsModel("X150") || ContainsModel("M350") || ContainsModel("K650") || ContainsModel("UM53") || ContainsModel("K660") || ContainsModel("UX84") || ContainsModel("M650") || ContainsModel("M550") || ContainsModel("K340") || ContainsModel("K350") || ContainsModel("M140") || ContainsModel("UM340") || ContainsModel("S540") || ContainsModel("M7400") || ContainsModel("N650") || ContainsModel("HN7306") || ContainsModel("H7606") || ContainsModel("UX5406") || ContainsModel("UM5606");
     }
 
     public static bool IsNoOverdrive()


### PR DESCRIPTION
Also I have just spotted there are both OLED and non-OLED SKUs under the same model:

https://www.asus.com/laptops/for-home/zenbook/zenbook-14x-ux5401-11th-gen-intel/techspec/
https://www.asus.com/laptops/for-home/zenbook/zenbook-14x-oled-ux5401-11th-gen-intel/techspec/

Maybe we need some new approach to check OLED.