### PR TITLE
Fix the CameraShutter-related logic on UX5406

### DIFF
--- a/app/Input/InputDispatcher.cs
+++ b/app/Input/InputDispatcher.cs
@@ -956,6 +956,14 @@ namespace GHelper.Input
                 Program.acpi.DeviceSet(AsusACPI.CameraShutter, 0, "CameraShutterOff");
                 Program.toast.RunToast($"Camera On");
             }
+            else if (cameraShutter == 262144)
+            {
+                Program.toast.RunToast($"Camera Off");
+            }
+            else if (cameraShutter == 262145)
+            {
+                Program.toast.RunToast($"Camera On");
+            }
             else
             {
                 if (!ProcessHelper.IsUserAdministrator()) return;


### PR DESCRIPTION
I apologize that my initial PR (#3358 ) did not correctly implement this feature. Initially, although I disabled Secure Boot and used tools like IRPMon to monitor ACPI messages sent by MyASUS, I found that the same DSTS message was sent regardless of whether the Camera was turned on or off. I assumed there was an issue with my monitoring setup, so I looked up asus-shutter-linux on GitHub and referenced that project to implement the relevant logic.

In my environment, OSD is disabled, and I did not run Visual Studio with administrator privileges. Under these conditions, the related keys functioned as expected following the logic from asus-shutter-linux. However, after running the 'scan' function, I noticed that on my machine (which differs from the model indicated in asus-shutter-linux), the return values were '262144' or '262145' rather than '0' or '1'.

After some testing, I found that for the CameraToggle to work correctly, a corresponding DSTS message must be sent after pressing it. On my machine, the DEVS message is unnecessary, as sending it alone does not change the CameraShutter state (which makes sense, as it should not allow unauthorized activation of the camera). This version should now correctly implement the feature and is ready for merging.