### PR TITLE
Allow manual disabling of all functions related to the GPU

### DIFF
--- a/app/AnimeMatrix/AniMatrixControl.cs
+++ b/app/AnimeMatrix/AniMatrixControl.cs
@@ -37,7 +37,7 @@ namespace GHelper.AnimeMatrix
         {
             settings = settingsForm;
             if (!AppConfig.IsSlash() && !AppConfig.IsAnimeMatrix()) return;
-            
+
             try
             {
                 if (AppConfig.IsSlash())

--- a/app/AppConfig.cs
+++ b/app/AppConfig.cs
@@ -517,6 +517,11 @@ public static class AppConfig
         return ContainsModel("GA503") || ContainsModel("G533Q") || ContainsModel("GU502") || ContainsModel("GU603") || IsSlash();
     }
 
+    public static bool NoGpu()
+    {
+        return Is("no_gpu");
+    }
+
     public static bool IsStrixNumpad()
     {
         return ContainsModel("G713R");

--- a/app/Gpu/AMD/AmdGpuControl.cs
+++ b/app/Gpu/AMD/AmdGpuControl.cs
@@ -62,7 +62,7 @@ public class AmdGpuControl : IGpuControl
 
     public AmdGpuControl()
     {
-        if (!Adl2.Load())
+        if (!Adl2.Load() || AppConfig.NoGpu())
             return;
 
         try

--- a/app/Gpu/GPUModeControl.cs
+++ b/app/Gpu/GPUModeControl.cs
@@ -44,7 +44,7 @@ namespace GHelper.Gpu
                 // GPU mode not supported
                 if (eco < 0 && mux < 0)
                 {
-                    if (gpuExists is null) gpuExists = Program.acpi.GetFan(AsusFan.GPU) >= 0;
+                    if (gpuExists is null) gpuExists = (!AppConfig.NoGpu()) && Program.acpi.GetFan(AsusFan.GPU) >= 0;
                     settings.HideGPUModes((bool)gpuExists);
                 }
             }

--- a/app/HardwareControl.cs
+++ b/app/HardwareControl.cs
@@ -289,26 +289,29 @@ public static class HardwareControl
         {
             GpuControl?.Dispose();
 
-            IGpuControl _gpuControl = new NvidiaGpuControl();
-
-            if (_gpuControl.IsValid)
+            if (!AppConfig.NoGpu())
             {
-                GpuControl = _gpuControl;
-                Logger.WriteLine(GpuControl.FullName);
-                return;
-            }
+                IGpuControl _gpuControl = new NvidiaGpuControl();
 
-            _gpuControl.Dispose();
+                if (_gpuControl.IsValid)
+                {
+                    GpuControl = _gpuControl;
+                    Logger.WriteLine(GpuControl.FullName);
+                    return;
+                }
 
-            _gpuControl = new AmdGpuControl();
-            if (_gpuControl.IsValid)
-            {
-                GpuControl = _gpuControl;
-                if (GpuControl.FullName.Contains("6850M")) AppConfig.Set("xgm_special", 1);
-                Logger.WriteLine(GpuControl.FullName);
-                return;
-            }
-            _gpuControl.Dispose();
+                _gpuControl.Dispose();
+
+                _gpuControl = new AmdGpuControl();
+                if (_gpuControl.IsValid)
+                {
+                    GpuControl = _gpuControl;
+                    if (GpuControl.FullName.Contains("6850M")) AppConfig.Set("xgm_special", 1);
+                    Logger.WriteLine(GpuControl.FullName);
+                    return;
+                }
+                _gpuControl.Dispose();
+            }           
 
             Logger.WriteLine("dGPU not found");
             GpuControl = null;

--- a/app/Peripherals/Mouse/AsusMouse.cs
+++ b/app/Peripherals/Mouse/AsusMouse.cs
@@ -481,9 +481,8 @@ namespace GHelper.Peripherals.Mouse
         {
             try
             {
-                HidSharp.DeviceList.Local.GetHidDevices(VendorID(), ProductID())
-                    .First(x => x.DevicePath.Contains(path));
-                return true;
+                return HidSharp.DeviceList.Local.GetHidDevices(VendorID(), ProductID())
+                    .FirstOrDefault(x => x.DevicePath.Contains(path)) != null;
             }
             catch
             {


### PR DESCRIPTION
I noticed that when the software starts on my device, it throws some exceptions that are caught and properly handled. Despite my device not having any dGPU, the AsusFan.GPU endpoint still exists, which causes an unnecessary GPU panel to appear on my device. This PR aims to minimize exceptions during the normal execution of the software to slightly improve performance. More importantly, it will allow users to manually hide the GPU panel and automatically hide these related panels on devices that are known to lack a dGPU.