### PR TITLE
Synchronize the indicator light status of CameraShutter at startup.

### DIFF
--- a/app/Input/InputDispatcher.cs
+++ b/app/Input/InputDispatcher.cs
@@ -86,9 +86,14 @@ namespace GHelper.Input
             Program.acpi.DeviceInit();
 
             if (!OptimizationService.IsRunning())
+            {
+                Program.acpi.DeviceGet(AsusACPI.CameraShutter);
                 listener = new KeyboardListener(HandleEvent);
+            }
             else
+            {
                 Logger.WriteLine("Optimization service is running");
+            }
 
             InitBacklightTimer();
 

--- a/app/Peripherals/Mouse/AsusMouse.cs
+++ b/app/Peripherals/Mouse/AsusMouse.cs
@@ -481,9 +481,8 @@ namespace GHelper.Peripherals.Mouse
         {
             try
             {
-                HidSharp.DeviceList.Local.GetHidDevices(VendorID(), ProductID())
-                    .First(x => x.DevicePath.Contains(path));
-                return true;
+                return HidSharp.DeviceList.Local.GetHidDevices(VendorID(), ProductID())
+                    .FirstOrDefault(x => x.DevicePath.Contains(path)) != null;
             }
             catch
             {


### PR DESCRIPTION
Without this line of code, if the laptop is shut down while in the "Camera Off" state, the indicator light on the CameraShutter key will remain off after reboot, which does not reflect the actual state of the camera.