### PR TITLE
Show mic muted toast with optimizations service running

### DIFF
--- a/app/Helpers/Audio.cs
+++ b/app/Helpers/Audio.cs
@@ -13,7 +13,7 @@ namespace GHelper.Helpers
                 var mmDevice = enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Multimedia);
 
                 bool status = !commDevice.AudioEndpointVolume.Mute;
-                
+
                 commDevice.AudioEndpointVolume.Mute = status;
                 consoleDevice.AudioEndpointVolume.Mute = status;
                 mmDevice.AudioEndpointVolume.Mute = status;
@@ -23,6 +23,16 @@ namespace GHelper.Helpers
                 Logger.WriteLine(mmDevice.ToString() + ":" + status);
 
                 return status;
+            }
+        }
+
+        public static bool IsMuted()
+        {
+            using (var enumerator = new MMDeviceEnumerator())
+            {
+                var commDevice = enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
+
+                return commDevice.AudioEndpointVolume.Mute;
             }
         }
     }

--- a/app/Input/InputDispatcher.cs
+++ b/app/Input/InputDispatcher.cs
@@ -521,7 +521,7 @@ namespace GHelper.Input
                     action = "aura";
                 if (name == "fnf5")
                     action = "performance";
-                if (name == "m3" && !OptimizationService.IsRunning())
+                if (name == "m3")
                     action = "micmute";
                 if (name == "fnc")
                     action = "fnlock";
@@ -621,7 +621,7 @@ namespace GHelper.Input
 
         static void ToggleMic()
         {
-            bool muteStatus = Audio.ToggleMute();
+            bool muteStatus = OptimizationService.IsRunning() ? Audio.IsMuted() : Audio.ToggleMute();
             Program.toast.RunToast(muteStatus ? Properties.Strings.Muted : Properties.Strings.Unmuted, muteStatus ? ToastIcon.MicrophoneMute : ToastIcon.Microphone);
             if (AppConfig.IsVivoZenbook()) Program.acpi.DeviceSet(AsusACPI.MicMuteLed, muteStatus ? 1 : 0, "MicmuteLed");
         }


### PR DESCRIPTION
Right now, if ASUS optimizations service is running, there's no toast or anything to show that you muted or unmuted microphone.

I believe this is because optimization services handle muting microphone, and so g-helper shouldn't do it itself, which is reasonable. The problem is that optimization services don't create toasts for it.

These changes should keep existing behavior that if optimization service is running, g-helper doesn't mute the microphone, but will show a toast and change LED indicator to show that microphone is indeed muted.