### PR TITLE
An addition to the text in the extra menu:

### DIFF
--- a/app/Extra.Designer.cs
+++ b/app/Extra.Designer.cs
@@ -1322,7 +1322,7 @@ namespace GHelper
             checkGPUFix.Padding = new Padding(3);
             checkGPUFix.Size = new Size(802, 40);
             checkGPUFix.TabIndex = 9;
-            checkGPUFix.Text = "Enable GPU on shutdown (prevents issue with Eco mode)";
+            checkGPUFix.Text = "Enable GPU on shutdown (prevents issues with Eco mode & brightness slider)";
             checkGPUFix.UseVisualStyleBackColor = true;
             // 
             // checkStatusLed

--- a/app/Properties/Strings.Designer.cs
+++ b/app/Properties/Strings.Designer.cs
@@ -826,7 +826,7 @@ namespace GHelper.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Enable GPU on shutdown (prevents issue with Eco mode).
+        ///   Looks up a localized string similar to Enable GPU on shutdown (prevents issues with Eco mode and brightness slider).
         /// </summary>
         internal static string EnableGPUOnShutdown {
             get {


### PR DESCRIPTION
> [!NOTE] 
> Where it says, under the Other Category : 
> "_Enable GPU on Shutdown (prevents issue with Eco mode)_" 

<div align="center"> 

![image](https://github.com/user-attachments/assets/af43a886-4701-463c-844b-afe6e40a5e3a) </div>

<hr>

> [!TIP] 
> it's changed by:
> "_Enable GPU on Shutdown (prevents issue_**s with Eco mode & brightness slider)**"

<div align="center"> Because activating this, also fixes the trouble of the brightness slider in most of laptops. </div>

<hr>