### PR TITLE
Added Arabic localization (Strings.ar.resx)

### DIFF
--- a/app/Properties/Strings.ar.resx
+++ b/app/Properties/Strings.ar.resx
@@ -1,0 +1,821 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Acceleration" xml:space="preserve">
+    <value>تسارع</value>
+  </data>
+  <data name="ACPIError" xml:space="preserve">
+    <value>تعذر الاتصال بنظام الطاقة المتقدم من أسوس. لا يمكن للتطبيق العمل بدون هذا النظام. يرجى محاولة تثبيت واجهة التحكم لنظام أسوس.</value>
+  </data>
+  <data name="AlertAPUMemoryRestart" xml:space="preserve">
+    <value>أعد تشغيل جهازك لتطبيق التغييرات</value>
+  </data>
+  <data name="AlertAPUMemoryRestartTitle" xml:space="preserve">
+    <value>هل تريد إعادة التشغيل الآن؟</value>
+  </data>
+  <data name="AlertDGPU" xml:space="preserve">
+    <value>يبدو أن وحدة معالجة الرسومات قيد الاستخدام المكثف، هل ترغب في تعطيلها؟</value>
+  </data>
+  <data name="AlertDGPUTitle" xml:space="preserve">
+    <value>وضع التوفير</value>
+  </data>
+  <data name="AlertUltimateOff" xml:space="preserve">
+    <value>إيقاف وضع الأداء العالي يتطلب إعادة تشغيل</value>
+  </data>
+  <data name="AlertUltimateOn" xml:space="preserve">
+    <value>تفعيل وضع الأداء العالي يتطلب إعادة تشغيل</value>
+  </data>
+  <data name="AlertUltimateTitle" xml:space="preserve">
+    <value>إعادة التشغيل الآن؟</value>
+  </data>
+  <data name="AllyController" xml:space="preserve">
+    <value>وحدة تحكم ألي</value>
+  </data>
+  <data name="AnimationSpeed" xml:space="preserve">
+    <value>سرعة الحركة</value>
+  </data>
+  <data name="AnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix</value>
+  </data>
+  <data name="AppAlreadyRunning" xml:space="preserve">
+    <value>التطبيق يعمل بالفعل</value>
+  </data>
+  <data name="AppAlreadyRunningText" xml:space="preserve">
+    <value>التطبيق يعمل بالفعل. يمكنك العثور على أيقونته في شريط المهام بجانب الساعة.</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>تطبيق</value>
+  </data>
+  <data name="ApplyFanCurve" xml:space="preserve">
+    <value>تطبيق منحنى المروحة المخصص</value>
+  </data>
+  <data name="ApplyPowerLimits" xml:space="preserve">
+    <value>تطبيق حدود الطاقة</value>
+  </data>
+  <data name="ApplyWindowsPowerPlan" xml:space="preserve">
+    <value>ضبط أوضاع طاقة ويندوز تلقائيًا</value>
+  </data>
+  <data name="APUMemory" xml:space="preserve">
+    <value>الذاكرة المخصصة لوحدة معالجة الرسومات</value>
+  </data>
+  <data name="AsusServicesRunning" xml:space="preserve">
+    <value>خدمات أسوس قيد التشغيل</value>
+  </data>
+  <data name="AuraBatteryState" xml:space="preserve">
+    <value>حالة البطارية</value>
+  </data>
+  <data name="AuraBreathe" xml:space="preserve">
+    <value>تنفس</value>
+  </data>
+  <data name="AuraClockwise" xml:space="preserve">
+    <value>باتجاه عقارب الساعة</value>
+  </data>
+  <data name="AuraColorCycle" xml:space="preserve">
+    <value>دورة الألوان</value>
+  </data>
+  <data name="AuraComet" xml:space="preserve">
+    <value>مذنب</value>
+  </data>
+  <data name="AuraCounterClockwise" xml:space="preserve">
+    <value>عكس عقارب الساعة</value>
+  </data>
+  <data name="AuraFast" xml:space="preserve">
+    <value>سريع</value>
+  </data>
+  <data name="AuraLightingMode" xml:space="preserve">
+    <value>وضع الإضاءة</value>
+  </data>
+  <data name="AuraNormal" xml:space="preserve">
+    <value>عادي</value>
+  </data>
+  <data name="AuraRainbow" xml:space="preserve">
+    <value>قوس قزح</value>
+  </data>
+  <data name="AuraRandomColor" xml:space="preserve">
+    <value>عشوائي</value>
+  </data>
+  <data name="AuraReact" xml:space="preserve">
+    <value>تفاعل</value>
+  </data>
+  <data name="AuraSlow" xml:space="preserve">
+    <value>بطيء</value>
+  </data>
+  <data name="AuraStatic" xml:space="preserve">
+    <value>ثابت</value>
+  </data>
+  <data name="AuraStrobe" xml:space="preserve">
+    <value>وميض</value>
+  </data>
+  <data name="AuraZoneAll" xml:space="preserve">
+    <value>الكل</value>
+  </data>
+  <data name="AuraZoneDock" xml:space="preserve">
+    <value>القاعدة</value>
+  </data>
+  <data name="AuraZoneLogo" xml:space="preserve">
+    <value>الشعار</value>
+  </data>
+  <data name="AuraZoneScroll" xml:space="preserve">
+    <value>عجلة التمرير</value>
+  </data>
+  <data name="AuraZoneUnderglow" xml:space="preserve">
+    <value>الإضاءة السفلية</value>
+  </data>
+  <data name="AutoApply" xml:space="preserve">
+    <value>تطبيق تلقائي</value>
+  </data>
+  <data name="AutoMode" xml:space="preserve">
+    <value>تلقائي</value>
+  </data>
+  <data name="AutoRefreshTooltip" xml:space="preserve">    
+  <value>يضبط الترددَ على 60 هرتز لتوفيرِ البطاريةِ، ويعود للوضعِ السابقِ عند التوصيلِ بالكهرباء</value>  
+  </data>
+  <data name="Awake" xml:space="preserve">
+    <value>نشط</value>
+  </data>
+  <data name="BacklightLow" xml:space="preserve">
+    <value>منخفض</value>
+  </data>
+  <data name="BacklightMax" xml:space="preserve">
+    <value>أقصى</value>
+  </data>
+  <data name="BacklightMid" xml:space="preserve">
+    <value>متوسط</value>
+  </data>
+  <data name="BacklightOff" xml:space="preserve">
+    <value>إيقاف</value>
+  </data>
+  <data name="BacklightTimeout" xml:space="preserve">
+    <value>مهلة الإضاءة عند التوصيل/على البطارية (0 - تشغيل)</value>
+  </data>
+  <data name="BacklightTimeoutBattery" xml:space="preserve">
+    <value>مهلة إضاءة الخلفية عند استخدام البطارية</value>
+  </data>
+  <data name="BacklightTimeoutPlugged" xml:space="preserve">
+    <value>مهلة إضاءة الخلفية عند التوصيل بالكهرباء</value>
+  </data>
+  <data name="Balanced" xml:space="preserve">
+    <value>متوازن</value>
+  </data>
+  <data name="BatteryCharge" xml:space="preserve">
+    <value>شحن</value>
+  </data>
+  <data name="BatteryChargeLimit" xml:space="preserve">
+    <value>حد شحن البطارية</value>
+  </data>
+  <data name="BatteryHealth" xml:space="preserve">
+    <value>صحة البطارية</value>
+  </data>
+  <data name="BatteryLimitFull" xml:space="preserve">
+    <value>شحن لمرة واحدة إلى 100٪</value>
+  </data>
+  <data name="Binding" xml:space="preserve">
+    <value>ربط</value>
+  </data>
+  <data name="BindingPrimary" xml:space="preserve">
+    <value>أساسي</value>
+  </data>
+  <data name="BindingSecondary" xml:space="preserve">
+    <value>ثانوي</value>
+  </data>
+  <data name="BiosAndDriverUpdates" xml:space="preserve">
+    <value>تحديثات البيوس والتعريفات</value>
+  </data>
+  <data name="Boot" xml:space="preserve">
+    <value>إقلاع</value>
+  </data>
+  <data name="BootSound" xml:space="preserve">
+    <value>صوت الإقلاع</value>
+  </data>
+  <data name="Brightness" xml:space="preserve">
+    <value>السطوع</value>
+  </data>
+  <data name="BrightnessDown" xml:space="preserve">
+    <value>تخفيض السطوع</value>
+  </data>
+  <data name="BrightnessUp" xml:space="preserve">
+    <value>رفع السطوع</value>
+  </data>
+  <data name="BWTrayIcon" xml:space="preserve">
+    <value>أيقونة شريط المهام بالأبيض والأسود</value>
+  </data>
+  <data name="Calibrate" xml:space="preserve">
+    <value>معايرة</value>
+  </data>
+  <data name="Charging" xml:space="preserve">
+    <value>جاري الشحن</value>
+  </data>
+  <data name="Color" xml:space="preserve">
+    <value>اللون</value>
+  </data>
+  <data name="Contrast" xml:space="preserve">
+    <value>التباين</value>
+  </data>
+  <data name="Controller" xml:space="preserve">
+    <value>وحدة التحكم</value>
+  </data>
+  <data name="CPUBoost" xml:space="preserve">
+    <value>تعزيز وحدة المعالجة المركزية</value>
+  </data>
+  <data name="Custom" xml:space="preserve">
+    <value>مخصص</value>
+  </data>
+  <data name="Deceleration" xml:space="preserve">
+    <value>إبطاء</value>
+  </data>
+  <data name="Default" xml:space="preserve">
+    <value>افتراضي</value>
+  </data>
+  <data name="DisableController" xml:space="preserve">
+    <value>تعطيل وحدة التحكم</value>
+  </data>
+  <data name="DisableOnLidClose" xml:space="preserve">
+    <value>تعطيل عند إغلاق الغطاء</value>
+  </data>
+  <data name="DisableOverdrive" xml:space="preserve">
+    <value>تعطيل تسريع الشاشة</value>
+  </data>
+  <data name="Discharging" xml:space="preserve">
+    <value>تفريغ الشحن</value>
+  </data>
+  <data name="DownloadColorProfiles" xml:space="preserve">
+    <value>تحميل ملفات تعريف الألوان</value>
+  </data>
+  <data name="DownloadUpdate" xml:space="preserve">
+    <value>تحميل</value>
+  </data>
+  <data name="DriverAndSoftware" xml:space="preserve">
+    <value>التعريفات والبرامج</value>
+  </data>
+  <data name="EcoGPUTooltip" xml:space="preserve">
+    <value>تعطيلُ كرتِ الشاشةِ المنفصلِ لتوفيرِ البطاريةِ</value>
+  </data>
+  <data name="EcoMode" xml:space="preserve">
+    <value>توفير الطاقة</value>
+  </data>
+  <data name="EnableGPUOnShutdown" xml:space="preserve">
+    <value>تفعيل كرت الشاشة عند الإغلاق (يمنع مشاكل وضع التوفير)</value>
+  </data>
+  <data name="EnableOptimusText" xml:space="preserve">
+    <value>تعطيل كرت الشاشة المنفصل عن طريق وضع التوفير بينما وضع العرض في لوحة تحكم NVIDIA غير مضبوط على Optimus قد يسبب مشاكل في التحكم بالسطوع حتى إعادة التشغيل القادمة.
+
+هل ترغب في المتابعة؟</value>
+  </data>
+  <data name="EnableOptimusTitle" xml:space="preserve">
+    <value>وضع عرض NVIDIA غير مضبوط على Optimus</value>
+  </data>
+  <data name="EnergySettings" xml:space="preserve">
+    <value>إعدادات الطاقة</value>
+  </data>
+  <data name="Export" xml:space="preserve">
+    <value>تصدير الملف الشخصي</value>
+  </data>
+  <data name="Extra" xml:space="preserve">
+    <value>إضافي</value>
+  </data>
+  <data name="ExtraSettings" xml:space="preserve">
+    <value>إعدادات إضافية</value>
+  </data>
+  <data name="FactoryDefaults" xml:space="preserve">
+    <value>إعدادات المصنع الافتراضية</value>
+  </data>
+  <data name="FanCurves" xml:space="preserve">
+    <value>منحنيات المروحة</value>
+  </data>
+  <data name="FanProfileCPU" xml:space="preserve">
+    <value>ملف تعريف مروحة وحدة المعالجة المركزية</value>
+  </data>
+  <data name="FanProfileGPU" xml:space="preserve">
+    <value>ملف تعريف مروحة وحدة معالجة الرسومات</value>
+  </data>
+  <data name="FanProfileMid" xml:space="preserve">
+    <value>ملف تعريف المروحة المتوسطة</value>
+  </data>
+  <data name="FanProfiles" xml:space="preserve">
+    <value>ملفات تعريف المروحة</value>
+  </data>
+  <data name="FansAndPower" xml:space="preserve">
+    <value>المراوح والطاقة</value>
+  </data>
+  <data name="FanSpeed" xml:space="preserve">
+    <value>المروحة</value>
+  </data>
+  <data name="FansPower" xml:space="preserve">
+    <value>المراوح + الطاقة</value>
+  </data>
+  <data name="FlickerFreeDimming" xml:space="preserve">
+    <value>تعتيم بدون وميض</value>
+  </data>
+  <data name="FnLock" xml:space="preserve">
+    <value>معالجة مفاتيح Fn+F بدون Fn</value>
+  </data>
+  <data name="FnLockOff" xml:space="preserve">
+    <value>إيقاف قفل FN</value>
+  </data>
+  <data name="FnLockOn" xml:space="preserve">
+    <value>تشغيل قفل FN</value>
+  </data>
+  <data name="GPUBoost" xml:space="preserve">
+    <value>تعزيز ديناميكي</value>
+  </data>
+  <data name="GPUChanging" xml:space="preserve">
+    <value>جاري التغيير</value>
+  </data>
+  <data name="GPUCoreClockOffset" xml:space="preserve">
+    <value>إزاحة تردد النواة</value>
+  </data>
+  <data name="GPUMemoryClockOffset" xml:space="preserve">
+    <value>إزاحة تردد الذاكرة</value>
+  </data>
+  <data name="GPUMode" xml:space="preserve">
+    <value>وضع وحدة معالجة الرسومات</value>
+  </data>
+  <data name="GPUModeEco" xml:space="preserve">
+    <value>وحدة معالجة الرسومات المدمجة فقط</value>
+  </data>
+  <data name="GPUModeStandard" xml:space="preserve">
+    <value>وحدة معالجة الرسومات المدمجة + المنفصلة</value>
+  </data>
+  <data name="GPUModeUltimate" xml:space="preserve">
+    <value>وحدة معالجة الرسومات المنفصلة حصرًا</value>
+  </data>
+  <data name="GPUPower" xml:space="preserve">
+    <value>طاقة وحدة معالجة الرسومات</value>
+  </data>
+  <data name="GPUSettings" xml:space="preserve">
+    <value>إعدادات وحدة معالجة الرسومات</value>
+  </data>
+  <data name="GPUTempTarget" xml:space="preserve">
+    <value>هدف درجة الحرارة</value>
+  </data>
+  <data name="HibernateAfter" xml:space="preserve">
+    <value>دقائق حتى السبات أثناء النوم على البطارية (0 - إيقاف)</value>
+  </data>
+  <data name="High" xml:space="preserve">
+    <value>مرتفع</value>
+  </data>
+  <data name="ImageRotation" xml:space="preserve">
+    <value>تدوير الصورة</value>
+  </data>
+  <data name="Import" xml:space="preserve">
+    <value>استيراد الملف الشخصي</value>
+  </data>
+  <data name="KeyBindings" xml:space="preserve">
+    <value>تعيينات المفاتيح</value>
+  </data>
+  <data name="Keyboard" xml:space="preserve">
+    <value>لوحة المفاتيح</value>
+  </data>
+  <data name="KillGpuApps" xml:space="preserve">
+    <value>إيقاف جميع التطبيقات التي تستخدم وحدة معالجة الرسومات عند التبديل إلى وضع التوفير</value>
+  </data>
+  <data name="LaptopBacklight" xml:space="preserve">
+    <value>إضاءة خلفية للحاسوب المحمول</value>
+  </data>
+  <data name="LaptopKeyboard" xml:space="preserve">
+    <value>لوحة مفاتيح الحاسوب المحمول</value>
+  </data>
+  <data name="LaptopScreen" xml:space="preserve">
+    <value>شاشة الحاسوب المحمول</value>
+  </data>
+  <data name="LEDStatusIndicators" xml:space="preserve">
+    <value>مؤشرات حالة LED</value>
+  </data>
+  <data name="Lid" xml:space="preserve">
+    <value>Lid</value>
+  </data>
+  <data name="Lightbar" xml:space="preserve">
+    <value>شريط الإضاءة</value>
+  </data>
+  <data name="Lighting" xml:space="preserve">
+    <value>الإضاءة</value>
+  </data>
+  <data name="LockScreen" xml:space="preserve">
+    <value>قفل الشاشة</value>
+  </data>
+  <data name="Logo" xml:space="preserve">
+    <value>الشعار</value>
+  </data>
+  <data name="Low" xml:space="preserve">
+    <value>منخفض</value>
+  </data>
+  <data name="LSDeadzones" xml:space="preserve">
+    <value>مناطق الخمول للعصا اليسرى</value>
+  </data>
+  <data name="LTDeadzones" xml:space="preserve">
+    <value>مناطق الخمول للزناد الأيسر</value>
+  </data>
+  <data name="MatrixAudio" xml:space="preserve">
+    <value>مؤثرات الصوت المرئية</value>
+  </data>
+  <data name="MatrixBanner" xml:space="preserve">
+    <value>لافتة ثنائية</value>
+  </data>
+  <data name="MatrixBright" xml:space="preserve">
+    <value>ساطع</value>
+  </data>
+  <data name="MatrixClock" xml:space="preserve">
+    <value>ساعة</value>
+  </data>
+  <data name="MatrixDim" xml:space="preserve">
+    <value>خافت</value>
+  </data>
+  <data name="MatrixLogo" xml:space="preserve">
+    <value>شعار ROG</value>
+  </data>
+  <data name="MatrixMedium" xml:space="preserve">
+    <value>متوسط</value>
+  </data>
+  <data name="MatrixOff" xml:space="preserve">
+    <value>إيقاف</value>
+  </data>
+  <data name="MatrixPicture" xml:space="preserve">
+    <value>صورة</value>
+  </data>
+  <data name="MaxRefreshTooltip" xml:space="preserve">
+    <value>أعلى معدل تحديث لأقل تأخير</value>
+  </data>
+  <data name="MinRefreshTooltip" xml:space="preserve">
+    <value>معدل تحديث 60 هرتز لتوفير البطارية</value>
+  </data>
+  <data name="Minute" xml:space="preserve">
+    <value>دقيقة</value>
+  </data>
+  <data name="Minutes" xml:space="preserve">
+    <value>دقائق</value>
+  </data>
+  <data name="MouseAngleSnapping" xml:space="preserve">
+    <value>تعديل زاوية الماوس</value>
+  </data>
+  <data name="MouseAutoPowerOff" xml:space="preserve">
+    <value>إيقاف تشغيل الماوس تلقائيًا بعد</value>
+  </data>
+  <data name="MouseButtonResponse" xml:space="preserve">
+    <value>استجابة أزرار الماوس</value>
+  </data>
+  <data name="MouseImportFailed" xml:space="preserve">
+    <value>فشل الاستيراد. الملف المحدد ليس ملف إعدادات ماوس صالح أو تالف.</value>
+  </data>
+  <data name="MouseLiftOffDistance" xml:space="preserve">
+    <value>مسافة رفع الماوس</value>
+  </data>
+  <data name="MouseLowBatteryWarning" xml:space="preserve">
+    <value>تحذير بطارية الماوس المنخفضة عند</value>
+  </data>
+  <data name="MousePerformance" xml:space="preserve">
+    <value>أداء</value>
+  </data>
+  <data name="MouseSynchronize" xml:space="preserve">
+    <value>مزامنة مع الماوس</value>
+  </data>
+  <data name="Multizone" xml:space="preserve">
+    <value>عدة مناطق</value>
+  </data>
+  <data name="MultizoneStrong" xml:space="preserve">
+    <value>عدة مناطق قوية</value>
+  </data>
+  <data name="Muted" xml:space="preserve">
+    <value>مكتوم</value>
+  </data>
+  <data name="MuteMic" xml:space="preserve">
+    <value>كتم الميكروفون</value>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>أبدًا</value>
+  </data>
+  <data name="NewUpdates" xml:space="preserve">
+    <value>تحديثات جديدة</value>
+  </data>
+  <data name="NoNewUpdates" xml:space="preserve">
+    <value>لا توجد تحديثات جديدة</value>
+  </data>
+  <data name="NotConnected" xml:space="preserve">
+    <value>غير متصل</value>
+  </data>
+  <data name="Off" xml:space="preserve">
+    <value>إيقاف</value>
+  </data>
+  <data name="On" xml:space="preserve">
+    <value>تشغيل</value>
+  </data>
+  <data name="OneZone" xml:space="preserve">
+    <value>منطقة واحدة</value>
+  </data>
+  <data name="OpenGHelper" xml:space="preserve">
+    <value>فتح نافذة G-Helper</value>
+  </data>
+  <data name="Optimized" xml:space="preserve">
+    <value>محسّن</value>
+  </data>
+  <data name="OptimizedGPUTooltip" xml:space="preserve">
+    <value>التبديلُ إلى وضعِ التوفيرِ عند استخدامِ البطاريةِ وإلى وضعٍ قياسيٍّ عند التوصيلِ بالكهرباءِ</value>
+  </data>
+  <data name="OptimizedUSBC" xml:space="preserve">
+    <value>الحفاظ على وحدة معالجة الرسومات معطلة عند استخدام شاحن USB-C في الوضع المحسّن</value>
+  </data>
+  <data name="Other" xml:space="preserve">
+    <value>أخرى</value>
+  </data>
+  <data name="Overdrive" xml:space="preserve">
+    <value>تسريع</value>
+  </data>
+  <data name="PerformanceMode" xml:space="preserve">
+    <value>وضع</value>
+  </data>
+  <data name="Peripherals" xml:space="preserve">
+    <value>الأجهزة الطرفية</value>
+  </data>
+  <data name="PictureGif" xml:space="preserve">
+    <value>صورة / Gif</value>
+  </data>
+  <data name="PlayPause" xml:space="preserve">
+    <value>تشغيل / إيقاف مؤقت</value>
+  </data>
+  <data name="PollingRate" xml:space="preserve">
+    <value>معدل الاستطلاع</value>
+  </data>
+  <data name="PowerLimits" xml:space="preserve">
+    <value>حدود الطاقة</value>
+  </data>
+  <data name="PPTExperimental" xml:space="preserve">
+    <value>حدود الطاقة هي ميزة تجريبية. استخدمها بحذر وعلى مسؤوليتك الخاصة!</value>
+  </data>
+  <data name="PrintScreen" xml:space="preserve">
+    <value>طباعة الشاشة</value>
+  </data>
+  <data name="Profile" xml:space="preserve">
+    <value>ملف التعريف</value>
+  </data>
+  <data name="Quit" xml:space="preserve">
+    <value>خروج</value>
+  </data>
+  <data name="Reset" xml:space="preserve">
+    <value>إعادة ضبط</value>
+  </data>
+  <data name="RestartGPU" xml:space="preserve">
+    <value>هناك شيء يستخدم وحدة معالجة الرسومات المنفصلة ويمنع وضع التوفير. هل تريد أن يحاول G-Helper إعادة تشغيل وحدة معالجة الرسومات في مدير الأجهزة؟ (يرجى المتابعة على مسؤوليتك الخاصة)</value>
+  </data>
+  <data name="RPM" xml:space="preserve">
+    <value>دورة في الدقيقة</value>
+  </data>
+  <data name="RSDeadzones" xml:space="preserve">
+    <value>مناطق الخمول للعصا اليمنى</value>
+  </data>
+  <data name="RTDeadzones" xml:space="preserve">
+    <value>مناطق الخمول للزناد الأيمن</value>
+  </data>
+  <data name="RunOnStartup" xml:space="preserve">
+    <value>تشغيل عند بدء النظام</value>
+  </data>
+  <data name="ScalingQuality" xml:space="preserve">
+    <value>جودة التحجيم</value>
+  </data>
+  <data name="ScreenPadDown" xml:space="preserve">
+    <value>خفض سطوع ScreenPad</value>
+  </data>
+  <data name="ScreenPadUp" xml:space="preserve">
+    <value>زيادة سطوع ScreenPad</value>
+  </data>
+  <data name="Shutdown" xml:space="preserve">
+    <value>إيقاف التشغيل</value>
+  </data>
+  <data name="Silent" xml:space="preserve">
+    <value>هادئ</value>
+  </data>
+  <data name="Sleep" xml:space="preserve">
+    <value>سكون</value>
+  </data>
+  <data name="StandardGPUTooltip" xml:space="preserve">
+    <value>تفعيلُ وحدةِ معالجةِ الرسوماتِ المنفصلةِ للاستخدامِ القياسيِّ</value>
+  </data>
+  <data name="StandardMode" xml:space="preserve">
+    <value>قياسي</value>
+  </data>
+  <data name="Start" xml:space="preserve">
+    <value>بدء</value>
+  </data>
+  <data name="StartingServices" xml:space="preserve">
+    <value>بدء الخدمات</value>
+  </data>
+  <data name="StartupError" xml:space="preserve">
+    <value>خطأ في بدء التشغيل</value>
+  </data>
+  <data name="Stop" xml:space="preserve">
+    <value>إيقاف</value>
+  </data>
+  <data name="StopGPUApps" xml:space="preserve">
+    <value>إيقاف تطبيقات وحدة معالجة الرسومات</value>
+  </data>
+  <data name="StoppingServices" xml:space="preserve">
+    <value>إيقاف الخدمات</value>
+  </data>
+  <data name="ToggleAura" xml:space="preserve">
+    <value>تبديل Aura</value>
+  </data>
+  <data name="ToggleClamshellMode" xml:space="preserve">
+    <value>تبديل وضع الحاسوب المغلق تلقائيًا</value>
+  </data>
+  <data name="ToggleFnLock" xml:space="preserve">
+    <value>تبديل قفل Fn</value>
+  </data>
+  <data name="ToggleMiniled" xml:space="preserve">
+    <value>تبديل Miniled (إذا كان مدعومًا)</value>
+  </data>
+  <data name="ToggleScreen" xml:space="preserve">
+    <value>تبديل الشاشة</value>
+  </data>
+  <data name="ToggleTouchscreen" xml:space="preserve">
+    <value>تبديل شاشة اللمس</value>
+  </data>
+  <data name="Touchscreen" xml:space="preserve">
+    <value>شاشة اللمس</value>
+  </data>
+  <data name="Turbo" xml:space="preserve">
+    <value>توربو</value>
+  </data>
+  <data name="TurnedOff" xml:space="preserve">
+    <value>تم إيقافها</value>
+  </data>
+  <data name="TurnOffOnBattery" xml:space="preserve">
+    <value>تعطيل على البطارية</value>
+  </data>
+  <data name="UltimateGPUTooltip" xml:space="preserve">
+    <value>توجيهُ شاشةِ الحاسوبِ المحمولِ إلى وحدةِ معالجةِ الرسوماتِ المنفصلةِ، مما يزيدُ عددَ الإطاراتِ في الثانيةِ</value>
+  </data>
+  <data name="UltimateMode" xml:space="preserve">
+    <value>مستوى عالي</value>
+  </data>
+  <data name="UndervoltingRisky" xml:space="preserve">
+    <value>تقليل الفولتية هي ميزة تجريبية وخطرة. إذا كانت القيم المطبقة منخفضة جدًا لجهازك، فقد يصبح غير مستقر، أو يتوقف أو يتسبب في تلف البيانات. إذا كنت ترغب في التجربة - ابدأ بقيم صغيرة أولاً، انقر على تطبيق واختبر ما يناسبك.</value>
+  </data>
+  <data name="Unmuted" xml:space="preserve">
+    <value>غير مكتوم</value>
+  </data>
+  <data name="Updates" xml:space="preserve">
+    <value>التحديثات</value>
+  </data>
+  <data name="VersionLabel" xml:space="preserve">
+    <value>الإصدار</value>
+  </data>
+  <data name="VibrationStrength" xml:space="preserve">
+    <value>قوة الاهتزاز</value>
+  </data>
+  <data name="VisualMode" xml:space="preserve">
+    <value>وضع العرض</value>
+  </data>
+  <data name="VisualModesHDR" xml:space="preserve">
+    <value>أوضاع العرض غير متاحة عندما يكون HDR نشطًا</value>
+  </data>
+  <data name="VisualModesScreen" xml:space="preserve">
+    <value>أوضاع العرض غير متاحة عندما تكون شاشة الحاسوب المحمول مطفأة</value>
+  </data>
+  <data name="VolumeDown" xml:space="preserve">
+    <value>خفض الصوت</value>
+  </data>
+  <data name="VolumeMute" xml:space="preserve">
+    <value>كتم الصوت</value>
+  </data>
+  <data name="VolumeUp" xml:space="preserve">
+    <value>رفع الصوت</value>
+  </data>
+  <data name="WindowTop" xml:space="preserve">
+    <value>إبقاء نافذة التطبيق دائمًا في المقدمة</value>
+  </data>
+  <data name="Zoom" xml:space="preserve">
+    <value>تكبير</value>
+  </data>
+  <data name="Donate" xml:space="preserve">
+    <value>تبرع</value>
+  </data>
+  <data name="Legend" xml:space="preserve">
+    <value>مفتاح الرموز</value>
+  </data>
+  <data name="LegendGray" xml:space="preserve">
+    <value>لا يمكن التحقق من الإصدار المحلي</value>
+    <comment>Can't check local version</comment>
+  </data>
+  <data name="LegendRed" xml:space="preserve">
+    <value>يتوفر تحديث</value>
+    <comment>Update Available</comment>
+  </data>
+  <data name="LegendGreen" xml:space="preserve">
+    <value>محدّث</value>
+    <comment>Updated</comment>
+  </data>
+</root>


### PR DESCRIPTION
Hi @seerge 

This PR introduces Arabic language support to G-Helper.

I have translated the existing English strings from `Strings.resx` into Arabic and included them in the new `Strings.ar.resx` file. 

However, during the translation process, I noticed several UI text elements that appear to be hardcoded directly in the source files rather than being sourced from the resource files. 

Here are some examples I spotted:

*   **Main UI Elements:**
    *   "Slash Lighting" (and its modes "Bounce, Slash, Loading, Bitstream and whatnot", "Interval Off", and interval values like "Interval Xs") appears in `app/Settings.cs`.
    *   "FN-Lock" (and its on/off states for button text and toast notifications) seems to be in `app/Settings.cs` and `app/Input/InputDispatcher.cs`.

*   **Extra Settings UI (`app/Extra.cs` and `app/Extra.Designer.cs`):**
    *   Section title "CPU Cores Configuration" and associated labels/dropdown text like "Pcores", "Ecores", and the "Apply" button.
    *   The term "action" next to the M-key/FN-key binding dropdowns.
    *   Time unit suffixes like "(sec)" and "(min)" for input fields.
  


![Screenshot 2025-05-14 211819](https://github.com/user-attachments/assets/08fda321-d162-47ec-a91a-2490ac2ea6d5)


