### PR TITLE
Add Overvolt setting for Power Users 

### DIFF
--- a/app/Ryzen/RyzenControl.cs
+++ b/app/Ryzen/RyzenControl.cs
@@ -14,7 +14,7 @@ namespace Ryzen
     {
 
         public static int MinCPUUV => AppConfig.Get("min_uv", -40);
-        public const int MaxCPUUV = 0;
+        public static int MaxCPUUV => AppConfig.Get("max_uv", 0);
 
         public const int MinIGPUUV = -20;
         public const int MaxIGPUUV = 0;


### PR DESCRIPTION
This is a very simple change that allows for CPU Overvolting in the config file by adding a "max_uv" variable.

I have an odd GA401QM that freezes/BSODs on idle when using the "Best Power Efficiency" power mode without a 15mV overvolt.