### PR TITLE
feat: Add nonstop performance mode reset feature

### DIFF
--- a/app/Extra.Designer.cs
+++ b/app/Extra.Designer.cs
@@ -1198,6 +1198,8 @@ namespace GHelper
             panelSettings.Controls.Add(checkVariBright);
             panelSettings.Controls.Add(checkGpuApps);
             panelSettings.Controls.Add(checkGPUFix);
+            panelSettings.Controls.Add(checkResetPerformanceMode);
+            panelSettings.Controls.Add(numericResetPerformanceMode);
             panelSettings.Controls.Add(checkOptimalBrightness);
             panelSettings.Controls.Add(checkStatusLed);
             panelSettings.Controls.Add(checkPerKeyRGB);
@@ -1620,6 +1622,33 @@ namespace GHelper
             checkOptimalBrightness.UseVisualStyleBackColor = true;
             checkOptimalBrightness.Visible = false;
             // 
+            // checkResetPerformanceMode
+            //
+            checkResetPerformanceMode.AutoSize = true;
+            checkResetPerformanceMode.Dock = DockStyle.Top;
+            checkResetPerformanceMode.Location = new Point(18, 484);
+            checkResetPerformanceMode.Margin = new Padding(4, 3, 4, 3);
+            checkResetPerformanceMode.Name = "checkResetPerformanceMode";
+            checkResetPerformanceMode.Padding = new Padding(3);
+            checkResetPerformanceMode.Size = new Size(802, 40);
+            checkResetPerformanceMode.TabIndex = 15;
+            checkResetPerformanceMode.Text = "Enable nonstop performance mode reset";
+            checkResetPerformanceMode.UseVisualStyleBackColor = true;
+            //
+            // numericResetPerformanceMode
+            //
+            numericResetPerformanceMode.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            numericResetPerformanceMode.Location = new Point(690, 489);
+            numericResetPerformanceMode.Margin = new Padding(4, 3, 4, 3);
+            numericResetPerformanceMode.Maximum = new decimal(new int[] { 3600, 0, 0, 0 });
+            numericResetPerformanceMode.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            numericResetPerformanceMode.Name = "numericResetPerformanceMode";
+            numericResetPerformanceMode.Size = new Size(122, 35);
+            numericResetPerformanceMode.TabIndex = 16;
+            numericResetPerformanceMode.Unit = "sec";
+            numericResetPerformanceMode.UnitFirst = false;
+            numericResetPerformanceMode.Value = new decimal(new int[] { 3, 0, 0, 0 });
+            //
             // Extra
             // 
             AutoScaleDimensions = new SizeF(168F, 168F);
@@ -1810,5 +1839,7 @@ namespace GHelper
         private CheckBox checkBatteryLid;
         private CheckBox checkBatteryBar;
         private CheckBox checkOptimalBrightness;
+        private CheckBox checkResetPerformanceMode;
+        private NumericUpDownWithUnit numericResetPerformanceMode;
     }
 }

--- a/app/Extra.cs
+++ b/app/Extra.cs
@@ -478,6 +478,32 @@ namespace GHelper
 
             InitACPITesting();
 
+            checkResetPerformanceMode.Checked = AppConfig.Is("reset_performance_mode");
+            checkResetPerformanceMode.CheckedChanged += CheckResetPerformanceMode_CheckedChanged;
+            numericResetPerformanceMode.Value = AppConfig.Get("reset_performance_mode_interval", 3);
+            numericResetPerformanceMode.ValueChanged += NumericResetPerformanceMode_ValueChanged;
+        }
+
+        private void CheckResetPerformanceMode_CheckedChanged(object? sender, EventArgs e)
+        {
+            AppConfig.Set("reset_performance_mode", (checkResetPerformanceMode.Checked ? 1 : 0));
+            if (checkResetPerformanceMode.Checked)
+            {
+                Program.modeControl.StartResetPerformanceModeTimer((int)numericResetPerformanceMode.Value);
+            }
+            else
+            {
+                Program.modeControl.StopResetPerformanceModeTimer();
+            }
+        }
+
+        private void NumericResetPerformanceMode_ValueChanged(object? sender, EventArgs e)
+        {
+            AppConfig.Set("reset_performance_mode_interval", (int)numericResetPerformanceMode.Value);
+            if (checkResetPerformanceMode.Checked)
+            {
+                Program.modeControl.StartResetPerformanceModeTimer((int)numericResetPerformanceMode.Value);
+            }
         }
 
         private void CheckOptimalBrightness_CheckedChanged(object? sender, EventArgs e)

--- a/app/Mode/ModeControl.cs
+++ b/app/Mode/ModeControl.cs
@@ -20,12 +20,33 @@ namespace GHelper.Mode
 
         static System.Timers.Timer reapplyTimer = default!;
         static System.Timers.Timer modeToggleTimer = default!;
+        static System.Timers.Timer resetTimer = default!;
 
         public ModeControl()
         {
             reapplyTimer = new System.Timers.Timer(AppConfig.GetMode("reapply_time", 30) * 1000);
             reapplyTimer.Enabled = false;
             reapplyTimer.Elapsed += ReapplyTimer_Elapsed;
+
+            resetTimer = new System.Timers.Timer();
+            resetTimer.Elapsed += ResetTimer_Elapsed;
+        }
+
+        private void ResetTimer_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
+        {
+            ResetPerformanceMode();
+        }
+
+        public void StartResetPerformanceModeTimer(int interval)
+        {
+            resetTimer.Stop();
+            resetTimer.Interval = interval * 1000;
+            resetTimer.Start();
+        }
+
+        public void StopResetPerformanceModeTimer()
+        {
+            resetTimer.Stop();
         }
 
 


### PR DESCRIPTION
This commit adds a new feature to the Extra settings that allows you to enable a nonstop performance mode reset.

A new checkbox and a numeric input field have been added to the Extra form. When the checkbox is enabled, a timer is started that calls `modeControl.ResetPerformanceMode()` at the interval specified by you.

The `ModeControl` class has been updated to include a new timer and methods to start and stop it. The timer's elapsed event handler calls `ResetPerformanceMode()`.