### PR TITLE
Extended battery limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# JetBrains Rider
+*.idea
+
 # User-specific files
 *.rsuser
 *.suo

--- a/app/Battery/BatteryControl.cs
+++ b/app/Battery/BatteryControl.cs
@@ -92,7 +92,7 @@ namespace GHelper.Battery
         /// <summary>
         /// Workaround for precise regulation of battery charge limit on models normally limited to 60% or 80%. Periodically monitors windows battery level and adjusts the charge limit accordingly.
         /// </summary>
-        /// <param name="interval">Time between </param>
+        /// <param name="interval">Time between checks.</param>
         public static async Task Regulate6080BatteryChargeLimit(TimeSpan interval)
         {
             var timer = new PeriodicTimer(interval);
@@ -114,12 +114,13 @@ namespace GHelper.Battery
                 var batteryLevel = SystemInformation.PowerStatus.BatteryLifePercent;
                 var setLimit = 100;
 
-                if (batteryLevel >= limit)
+                if (batteryLevel * 100 >= limit)
                 {
                     setLimit = 60;
                 }
 
-                Program.acpi.DeviceSet(AsusACPI.BatteryLimit, setLimit, "BatteryLimit");
+                // LogName is null otherwise we spam the logs
+                Program.acpi.DeviceSet(AsusACPI.BatteryLimit, setLimit, null);
             }
         }
     }

--- a/app/Battery/BatteryControl.cs
+++ b/app/Battery/BatteryControl.cs
@@ -54,10 +54,6 @@ namespace GHelper.Battery
 
             if (AppConfig.IsChargeLimit6080())
             {
-                // if (limit > 85) limit = 100;
-                // else if (limit >= 80) limit = 80;
-                // else if (limit < 60) limit = 60;
-
                 if (limit < 60) limit = 60;
             }
 
@@ -90,7 +86,7 @@ namespace GHelper.Battery
         }
 
         /// <summary>
-        /// Workaround for precise regulation of battery charge limit on models normally limited to 60% or 80%. Periodically monitors windows battery level and adjusts the charge limit accordingly.
+        /// Workaround to allow charge limits between 80% and 100% on models normally limited to between 60% and 80%. Periodically monitors windows battery level and adjusts the charge limit accordingly.
         /// </summary>
         /// <param name="interval">Time between checks.</param>
         public static async Task Regulate6080BatteryChargeLimit(TimeSpan interval)
@@ -106,7 +102,8 @@ namespace GHelper.Battery
 
                 var limit = AppConfig.Get("charge_limit");
 
-                if (limit <= 60)
+                // Don't need to worry about below 80, this is supported natively
+                if (limit <= 80)
                 {
                     continue;
                 }

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -127,6 +127,10 @@ namespace GHelper
             unRegPowerNotify = NativeMethods.RegisterPowerSettingNotification(settingsForm.Handle, PowerSettingGuid.ConsoleDisplayState, NativeMethods.DEVICE_NOTIFY_WINDOW_HANDLE);
             unRegPowerNotifyLid = NativeMethods.RegisterPowerSettingNotification(settingsForm.Handle, PowerSettingGuid.LIDSWITCH_STATE_CHANGE, NativeMethods.DEVICE_NOTIFY_WINDOW_HANDLE);
 
+            if (AppConfig.IsChargeLimit6080())
+            {
+                Task.Run(() => BatteryControl.Regulate6080BatteryChargeLimit(TimeSpan.FromSeconds(5)));
+            }
 
             Task task = Task.Run((Action)PeripheralsProvider.DetectAllAsusMice);
             PeripheralsProvider.RegisterForDeviceEvents();


### PR DESCRIPTION
Some laptops like my G16 2025 don't support charging limits outside of 60 to 80 percent

This PR adds a workaround to allow limits from 80 to 100 - the limit is set to 100 until it detects the charge equals or exceeds the user's setting, then its reduced to 60 which actually has the effect of keeping the battery at the current level

It is a bit hacky though, requires constantly monitoring the windows battery level and setting the limit accordingly, I've set the interval at 5 seconds per poll at least so I don't think resource usage should be a concern

Also unfortunately below 60 is still not supported as 60 is the lowest limit afaik...?

Let me know what you think and if you see any issues with it, new to this codebase, could probably use testing on the other machines with these limits too