### PR TITLE
Fix: prevent CultureNotFoundException by adding fallback to en

### DIFF
--- a/app/Program.cs
+++ b/app/Program.cs
@@ -59,7 +59,14 @@ namespace GHelper
             string language = AppConfig.GetString("language");
 
             if (language != null && language.Length > 0)
-                Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(language);
+                try
+                {
+                    Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(language);
+                }
+                catch (CultureNotFoundException)
+                {
+                    Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("en");
+                }
             else
             {
                 var culture = CultureInfo.CurrentUICulture;


### PR DESCRIPTION
## Problem

GHelper crashed on my system with following error:
Application: GHelper.exe
CoreCLR Version: 8.0.1625.21506
.NET Version: 8.0.16
Description: The process was terminated due to an unhandled exception.
Exception Info: System.Globalization.CultureNotFoundException: Culture is not supported. (Parameter 'name')
{
    "language": "en_us",
    "fallback": "en_us",
    "document": "en"
  } is an invalid culture identifier.
   at System.Globalization.CultureInfo.GetCultureInfo(String name)
   at GHelper.Program.Main(String[] args) in D:\a\g-helper\g-helper\app\Program.cs:line 62
   
## Solution

This pull request improves the application's handling of invalid or unsupported language codes during startup. Now, if an invalid language code is provided, the application will gracefully fall back to English instead of throwing an exception.

Error handling and localization:

* Updated `Main` in `app/Program.cs` to wrap the culture assignment in a try-catch block, catching `CultureNotFoundException` and defaulting to English (`"en"`) if the specified language is invalid.


Thanks for the project ❤️ Happy to improve this further if requested. Maybe add a proper CultureInfo normalization in the future?