### PR TITLE
Add priority setting

### DIFF
--- a/app/Helpers/ProcessHelper.cs
+++ b/app/Helpers/ProcessHelper.cs
@@ -145,6 +145,19 @@ namespace GHelper.Helpers
             return result;
         }
 
+        public static void SetPriority(ProcessPriorityClass priorityClass = ProcessPriorityClass.Normal)
+        {
+            try
+            {
+                using (Process p = Process.GetCurrentProcess())
+                    p.PriorityClass = priorityClass;
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteLine(ex.ToString());
+            }
+        }
+
 
     }
 }

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -69,6 +69,7 @@ namespace GHelper
             }
 
             ProcessHelper.CheckAlreadyRunning();
+            ProcessHelper.SetPriority();
 
             Logger.WriteLine("------------");
             Logger.WriteLine("App launched: " + AppConfig.GetModel() + " :" + Assembly.GetExecutingAssembly().GetName().Version.ToString() + CultureInfo.CurrentUICulture + (ProcessHelper.IsUserAdministrator() ? "." : ""));


### PR DESCRIPTION
Added automatically setting the process priority to normal on startup.

This can be expanded on by allowing the user to configure GHelper to automatically launch with a priority of choice.

This is necessary as the scheduled task runs it at below normal priority to prevent it from being the first to stop responding in case of CPU bottleneck.