### PR TITLE
Allow reordering custom performance modes (move up/down)

### DIFF
--- a/app/Fans.Designer.cs
+++ b/app/Fans.Designer.cs
@@ -352,15 +352,19 @@ namespace GHelper
             // 
             // tableLayoutModes
             // 
-            tableLayoutModes.ColumnCount = 4;
+            tableLayoutModes.ColumnCount = 6;
             tableLayoutModes.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 60F));
             tableLayoutModes.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 60F));
+            tableLayoutModes.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 36F));
+            tableLayoutModes.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 36F));
             tableLayoutModes.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
             tableLayoutModes.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 60F));
             tableLayoutModes.Controls.Add(buttonRemove, 0, 0);
-            tableLayoutModes.Controls.Add(buttonAdd, 3, 0);
             tableLayoutModes.Controls.Add(buttonRename, 1, 0);
-            tableLayoutModes.Controls.Add(comboModes, 2, 0);
+            tableLayoutModes.Controls.Add(buttonMoveUp, 2, 0);
+            tableLayoutModes.Controls.Add(buttonMoveDown, 3, 0);
+            tableLayoutModes.Controls.Add(comboModes, 4, 0);
+            tableLayoutModes.Controls.Add(buttonAdd, 5, 0);
             tableLayoutModes.Dock = DockStyle.Right;
             tableLayoutModes.Location = new Point(330, 0);
             tableLayoutModes.Margin = new Padding(0);
@@ -421,6 +425,40 @@ namespace GHelper
             buttonRename.Size = new Size(54, 46);
             buttonRename.TabIndex = 45;
             buttonRename.UseVisualStyleBackColor = false;
+            // 
+            // buttonMoveUp
+            // 
+            buttonMoveUp.Activated = false;
+            buttonMoveUp.BackColor = SystemColors.ControlLight;
+            buttonMoveUp.BorderColor = Color.Transparent;
+            buttonMoveUp.BorderRadius = 2;
+            buttonMoveUp.Dock = DockStyle.Fill;
+            buttonMoveUp.FlatStyle = FlatStyle.Flat;
+            buttonMoveUp.Text = "▲";
+            buttonMoveUp.Location = new Point(120, 10);
+            buttonMoveUp.Margin = new Padding(0, 0, 6, 0);
+            buttonMoveUp.Name = "buttonMoveUp";
+            buttonMoveUp.Secondary = true;
+            buttonMoveUp.Size = new Size(30, 46);
+            buttonMoveUp.TabIndex = 46;
+            buttonMoveUp.UseVisualStyleBackColor = false;
+            // 
+            // buttonMoveDown
+            // 
+            buttonMoveDown.Activated = false;
+            buttonMoveDown.BackColor = SystemColors.ControlLight;
+            buttonMoveDown.BorderColor = Color.Transparent;
+            buttonMoveDown.BorderRadius = 2;
+            buttonMoveDown.Dock = DockStyle.Fill;
+            buttonMoveDown.FlatStyle = FlatStyle.Flat;
+            buttonMoveDown.Text = "▼";
+            buttonMoveDown.Location = new Point(156, 10);
+            buttonMoveDown.Margin = new Padding(0, 0, 6, 0);
+            buttonMoveDown.Name = "buttonMoveDown";
+            buttonMoveDown.Secondary = true;
+            buttonMoveDown.Size = new Size(30, 46);
+            buttonMoveDown.TabIndex = 47;
+            buttonMoveDown.UseVisualStyleBackColor = false;
             // 
             // comboModes
             // 
@@ -1877,6 +1915,8 @@ namespace GHelper
         private RButton buttonAdd;
         private RButton buttonRemove;
         private RButton buttonRename;
+        private RButton buttonMoveUp;
+        private RButton buttonMoveDown;
         private Panel panelUV;
         private Label labelUV;
         private Label labelLeftUV;

--- a/app/Fans.cs
+++ b/app/Fans.cs
@@ -110,6 +110,9 @@ namespace GHelper
 
             buttonReset.Click += ButtonReset_Click;
 
+            buttonMoveUp.Click += ButtonMoveUp_Click;
+            buttonMoveDown.Click += ButtonMoveDown_Click;
+
             trackTotal.Maximum = AsusACPI.MaxTotal;
             trackTotal.Minimum = AsusACPI.MinTotal;
 
@@ -509,6 +512,9 @@ namespace GHelper
             comboModes.DataSource = new BindingSource(Modes.GetDictonary(), null);
             comboModes.DisplayMember = "Value";
             comboModes.ValueMember = "Key";
+            // show/hide controls that only apply to custom modes
+            bool isCustom = Modes.IsCurrentCustom();
+            buttonRename.Visible = buttonRemove.Visible = buttonMoveUp.Visible = buttonMoveDown.Visible = isCustom;
             if (contextMenu) Program.settingsForm.SetContextMenu();
         }
 
@@ -519,11 +525,37 @@ namespace GHelper
             modeControl.SetPerformanceMode(mode);
         }
 
+        private void ButtonMoveUp_Click(object? sender, EventArgs e)
+        {
+            var selected = comboModes.SelectedValue;
+            if (selected == null) return;
+
+            int mode = (int)selected;
+            if (Modes.Move(mode, -1))
+            {
+                FillModes();
+                comboModes.SelectedValue = mode;
+            }
+        }
+
+        private void ButtonMoveDown_Click(object? sender, EventArgs e)
+        {
+            var selected = comboModes.SelectedValue;
+            if (selected == null) return;
+
+            int mode = (int)selected;
+            if (Modes.Move(mode, +1))
+            {
+                FillModes();
+                comboModes.SelectedValue = mode;
+            }
+        }
+
         public void InitMode()
         {
             int mode = Modes.GetCurrent();
             comboModes.SelectedValue = mode;
-            buttonRename.Visible = buttonRemove.Visible = Modes.IsCurrentCustom();
+            buttonRename.Visible = buttonRemove.Visible = buttonMoveUp.Visible = buttonMoveDown.Visible = Modes.IsCurrentCustom();
         }
 
         private void ComboModes_SelectedValueChanged(object? sender, EventArgs e)


### PR DESCRIPTION
Pull request created to address #4698

This pull request was created using GPT-5o. Functionality has not been tested. Based on limited understanding of the codebase the changes made should work in theory. Please test these changes thoroughly before approving merge.

Feature:
Adds Move Up / Move Down buttons to Fans UI and Swap/Move helpers in Modes to reorder custom performance profiles by swapping stored settings between mode slots.

Files Modified: 
app/Mode/Modes.cs: add Swap(int,int) and Move(int,direction)
app/Fans.Designer.cs: add move up/down buttons and layout changes
app/Fans.cs: wire handlers, visibility updates, and handlers for moving modes

Behavior: 
Only custom modes (IDs > 2) can be moved.
Moving swaps all per-mode AppConfig entries so settings remain attached to the moved profile.

How to test:
1. Build on Windows/Visual Studio.
2. In the Fans panel, add several custom modes.
3. Select a custom mode and click ▲ or ▼ to move it. Verify name and settings moved with it.
4. This is a small UI-first approach; follow-up can add drag-and-drop reordering or unit tests if desired.