### PR TITLE
Fix crash on wake when using Audio mode in AnimeMatrix

### DIFF
--- a/app/AnimeMatrix/AniMatrixControl.cs
+++ b/app/AnimeMatrix/AniMatrixControl.cs
@@ -360,12 +360,25 @@ namespace GHelper.AnimeMatrix
                 }
             }
 
+            AudioDevice = null; // Ensure this is nulled out
             AudioDeviceId = null;
 
-            if (AudioDeviceEnum is not null) {
-                AudioDeviceEnum?.UnregisterEndpointNotificationCallback(this);
-                AudioDeviceEnum?.Dispose();
+            if (AudioDeviceEnum is not null)
+            {
+                try
+                {
+                    //wrap it in try/catch so if Windows Audio is broken (sleep/wake),
+                    // we just ignore it and continue.
+                    AudioDeviceEnum.UnregisterEndpointNotificationCallback(this);
+                    AudioDeviceEnum.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    Logger.WriteLine("Failed to stop audio listener: " + ex.Message);
+                }
             }
+            //Clear the reference so we don't use a dead object later
+            AudioDeviceEnum = null; 
         }
 
         void SetAudio()


### PR DESCRIPTION
* Added exception handling to StopAudio to prevent NullReferenceException when the OS audio service is unavailable during sleep transitions.
* Improve https://github.com/seerge/g-helper/commit/7141cf13846c48d84fd3d021655783b0fe3fecd0