### PR TITLE
non-passthrough fix (issue #4953)

### DIFF
--- a/app/Program.cs
+++ b/app/Program.cs
@@ -305,7 +305,6 @@ namespace GHelper
 
         private static void SystemEvents_PowerModeChanged(object sender, PowerModeChangedEventArgs e)
         {
-            Logger.WriteLine($"Power Mode {e.Mode}: {SystemInformation.PowerStatus.PowerLineStatus}");
             if (e.Mode == PowerModes.Suspend)
             {
                 Logger.WriteLine("Power Mode Changed:" + e.Mode.ToString());
@@ -314,15 +313,19 @@ namespace GHelper
                 InputDispatcher.ShutdownStatusLed();
             }
 
+            if (AppConfig.Is("disable_power_event")) return;
+            if (SystemInformation.PowerStatus.PowerLineStatus == isPlugged) return;
+
+            Logger.WriteLine($"Power Mode {e.Mode}: {SystemInformation.PowerStatus.PowerLineStatus}");
+
             int delay = AppConfig.Get("charger_delay");
             if (delay > 0)
             {
                 Logger.WriteLine($"Charger Delay: {delay}");
                 Thread.Sleep(delay);
+                if (SystemInformation.PowerStatus.PowerLineStatus == isPlugged) return;
             }
 
-            if (SystemInformation.PowerStatus.PowerLineStatus == isPlugged) return;
-            if (AppConfig.Is("disable_power_event")) return;
             SetAutoModes(powerChanged: true);
         }
 


### PR DESCRIPTION
I just reordered the SystemEvents_PowerModeChanged function with two key changes:

1) Added an extra earlier "isPlugged ? then return" check to catch Windows triggering power mode change when it's still plugged
2) Move the Power Mode logger to a line after that, so that these random triggers don't spam the log all the time and cause unnecessary disk writes, consuming power
3) -Bonus- The "disable_power_event ? return" check is now done earlier as well because why not