### PR TITLE
Add power limits and model detection for TUF Gaming A14 FA401EA (AI MAX+ 392)

### DIFF
--- a/app/AppConfig.cs
+++ b/app/AppConfig.cs
@@ -672,12 +672,17 @@ public static class AppConfig
 
     public static bool IsAMDiGPU()
     {
-        return ContainsModel("GV301RA") || ContainsModel("GV302XA") || ContainsModel("GZ302") || IsAlly();
+        return ContainsModel("GV301RA") || ContainsModel("GV302XA") || ContainsModel("GZ302") || IsFA401EA() || IsAlly();
     }
 
     public static bool NoGpu()
     {
-        return Is("no_gpu") || ContainsModel("UX540") || ContainsModel("UM560") || ContainsModel("GZ302");
+        return Is("no_gpu") || ContainsModel("UX540") || ContainsModel("UM560") || ContainsModel("GZ302") || IsFA401EA();
+    }
+
+    public static bool IsFA401EA()
+    {
+        return ContainsModel("FA401EA");
     }
 
     public static bool IsHardwareTouchpadToggle()

--- a/app/AsusACPI.cs
+++ b/app/AsusACPI.cs
@@ -164,7 +164,7 @@ public class AsusACPI
     public static int DefaultTotal = 80;
 
     public const int MinCPU = 5;
-    public const int MaxCPU = 100;
+    public static int MaxCPU = 100;
     public const int DefaultCPU = 80;
 
     public const int MinGPUBoost = 5;
@@ -340,6 +340,11 @@ public class AsusACPI
             MaxTotal = 93;
         }
 
+        if (AppConfig.IsFA401EA())
+        {
+            MaxTotal = 115;
+            MaxCPU = 115;
+        }
 
     }
 


### PR DESCRIPTION
## Summary

  Add support for **ASUS TUF Gaming A14 2026 (FA401EA)** with **AMD AI MAX+ 392** processor:

  - Add `IsFA401EA()` helper method to `AppConfig` for consistent model detection (matches the `IsXxx()` pattern used throughout the codebase)
  - Set `MaxTotal` and `MaxCPU` to **115W** 
  - Change `MaxCPU` from `const` to `static` to allow runtime adjustment for this model
  - Register FA401EA in `IsAMDiGPU()` and `NoGpu()` since this device has no discrete GPU (the AI MAX 392 has integrated Radeon graphics only)

## Device info

  - **Model**: ASUS TUF Gaming A14 (FA401EA)
  - **CPU/APU**: AMD AI MAX 392 (Strix Halo)
  - **GPU**: Integrated Radeon only (no dGPU)
  - **Max TDP**: 115W (Note: The AMD AI MAX+ 392 is rated for up to 120W configurable TDP, but this specific device limits the maximum to 115W in my testing. If you find a way to achieve the full 120W on this model, please let me know!)

## Changes

  | File | Change |
  |------|--------|
  | `app/AppConfig.cs` | Add `IsFA401EA()`, use it in `IsAMDiGPU()` and `NoGpu()` |
  | `app/AsusACPI.cs` | Set MaxTotal=115, MaxCPU=115 for FA401EA; MaxCPU const→static |