### PR TITLE
AMD OLED Power Optimization causing washed colors alert fix

### DIFF
--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -484,6 +484,34 @@ namespace GHelper
             VisualiseDisabled();
         }
 
+        private void OLEDHDRWashWarning(bool hdr)
+        {
+            if (AppConfig.Is("oled_hdr_wash_warning_shown")) return;
+            if (!AppConfig.IsOLED()) // varibright affects OLED panels
+            {
+                return;
+            }
+            if (SystemInformation.PowerStatus.PowerLineStatus != PowerLineStatus.Offline) // on battery power
+            {
+                return;
+            }
+            if (!(AppConfig.IsG14AMD() || AppConfig.IsAMDLight() || AppConfig.IsAMDiGPU())) // AMD varibright only on AMD hardware
+            {
+                return;
+            }
+            if (hdr) // varibright only affects when on SDR
+            {
+                return;
+            }
+
+            string message = "On battery power and using SDR, OLED screen may be washed out due to AMD OLED Power Optimization.\n\nPlease disable OLED Power Optimization in AMD Software: Adrenalin Edition -> Settings -> Display -> OLED Power Optimization.\n\nClick Cancel to not show this message again.";
+
+            if (MessageBox.Show(message, "OLED Color Issue", MessageBoxButtons.OKCancel, MessageBoxIcon.Warning) == DialogResult.Cancel)
+            {
+                AppConfig.Set("oled_hdr_wash_warning_shown", 1);
+            }
+        }
+
         public void VisualiseBrightness()
         {
             Invoke(delegate
@@ -1293,6 +1321,8 @@ namespace GHelper
 
         public void VisualiseScreen(bool screenEnabled, bool screenAuto, int frequency, int maxFrequency, int overdrive, bool overdriveSetting, int miniled1, int miniled2, bool hdr, int fhd, int hdrControl)
         {
+
+            OLEDHDRWashWarning(hdr);
 
             ButtonEnabled(button60Hz, screenEnabled);
             ButtonEnabled(button120Hz, screenEnabled);

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Small and lightweight Armoury Crate alternative for Asus laptops offering almost
 - [FAQ](https://github.com/seerge/g-helper/wiki/FAQ)
 - [Setup and Requirements](https://github.com/seerge/g-helper/wiki/Requirements)
 - [Troubleshooting](https://github.com/seerge/g-helper/wiki/Troubleshooting)
+  - *Note: If you experience washed out colors on OLED screens on battery while using SDR, disable AMD OLED Power Optimization in AMD Software.*
 - [Power User Settings](https://github.com/seerge/g-helper/wiki/Power-user-settings)
 
 


### PR DESCRIPTION
Issue #4977 is fixed by adding a preventative pop up that appears when on battery, SDR, and on app open to notify users to disable AMD OLED power optimization. Popup gives users prompt to close regularly or close and not reopen. 

*Add to wiki in troubleshooting section rather than just where it was placed in README.md