### PR TITLE
Add full charging disabling strategies

### DIFF
--- a/app/Battery/IFullChargingDisabler.cs
+++ b/app/Battery/IFullChargingDisabler.cs
@@ -1,0 +1,6 @@
+﻿namespace GHelper.Battery;
+
+public interface IFullChargingDisabler
+{
+    public void TriggerChargingEvent(decimal? chargingRate, decimal chargingPercent);
+}

--- a/app/Battery/SimpleFullChargingDisabler.cs
+++ b/app/Battery/SimpleFullChargingDisabler.cs
@@ -1,0 +1,12 @@
+﻿namespace GHelper.Battery;
+
+public class SimpleFullChargingDisabler : IFullChargingDisabler
+{
+    public void TriggerChargingEvent(decimal? chargingRate, decimal chargingPercent)
+    {
+        if (chargingPercent >= 100 && BatteryControl.chargeFull)
+        {
+            BatteryControl.UnSetBatteryLimitFull();
+        }
+    }
+}

--- a/app/Battery/TimeoutFullChargingDissabler.cs
+++ b/app/Battery/TimeoutFullChargingDissabler.cs
@@ -1,0 +1,35 @@
+﻿using System.Diagnostics;
+using Microsoft.VisualBasic.Logging;
+
+namespace GHelper.Battery;
+
+public class TimeoutFullChargingDisabler : IFullChargingDisabler
+{
+    private decimal lastChargingRate = 1;
+    private DateTime lastChargingModeSwitch;
+    
+    public TimeoutFullChargingDisabler() {}
+    
+    public void TriggerChargingEvent(decimal? chargingRate, decimal chargingPercent)
+    {
+        if (chargingPercent >= 100)
+        {
+            SetBatteryLimitFullSafe();
+        }
+
+        if (lastChargingRate * (chargingRate ?? 0) <= 0)
+        {
+            lastChargingModeSwitch = DateTime.Now;
+        }
+        lastChargingRate = chargingRate ?? 0;
+        
+        if (chargingRate < 0 && DateTime.Now.Subtract(lastChargingModeSwitch).TotalMinutes > 1) {
+            SetBatteryLimitFullSafe();
+        }
+    }
+
+    private void SetBatteryLimitFullSafe()
+    {
+        if (BatteryControl.chargeFull) BatteryControl.UnSetBatteryLimitFull();
+    }
+}

--- a/app/HardwareControl.cs
+++ b/app/HardwareControl.cs
@@ -12,6 +12,7 @@ public static class HardwareControl
 {
 
     public static IGpuControl? GpuControl;
+    public static IFullChargingDisabler fullChargingDisabler = new TimeoutFullChargingDisabler();
 
     public static float? cpuTemp = -1;
     public static float? gpuTemp = -1;
@@ -266,7 +267,7 @@ public static class HardwareControl
         if (fullCapacity > 0 && chargeCapacity > 0)
         {
             batteryCapacity = Math.Min(100, (decimal)chargeCapacity / (decimal)fullCapacity * 100);
-            if (batteryCapacity > 99 && BatteryControl.chargeFull) BatteryControl.UnSetBatteryLimitFull();
+            fullChargingDisabler.TriggerChargingEvent(batteryRate, batteryCapacity);
             if (chargeWatt)
             {
                 batteryCharge = Math.Round((decimal)chargeCapacity / 1000, 1).ToString() + "Wh";


### PR DESCRIPTION
I think "Full charge" button should be disable automatically even if device wasn't charged to 100%

For example: i use my laptop with minimal available battery limit to save battery life. But when i decided to go out i use this feature to have more energy outside. But i am not expected to charge battery to 100%. After returning to home when laptop will be attached to charger it start to charge to full because this feature was activated and laptop wasn't charged to 100%

I propose to use following logic: app will track when battery mode is changed (attached or detached to charger). And if battery mod is change for some period of time and it is detached - turn off full charging mode

This PR should be improved to:
1. move threshold to config
2. add option to select which mode to use

I didn't do it yet because i want to get approve for this feature