### PR TITLE
Add g615lw per key rgb in configs

### DIFF
--- a/app/AppConfig.cs
+++ b/app/AppConfig.cs
@@ -520,7 +520,7 @@ public static class AppConfig
 
     public static bool IsStrixLimitedRGB()
     {
-        return ContainsModel("G614PM") || ContainsModel("G614PP") || ContainsModel("G614PR") || ContainsModel("G512LI") || ContainsModel("G513R") || ContainsModel("G713QM") || ContainsModel("G713PV") || ContainsModel("G513IE") || ContainsModel("G713RC") || ContainsModel("G713IC") || ContainsModel("G713PU") || ContainsModel("G513QM") || ContainsModel("G513QC") || ContainsModel("G531G") || ContainsModel("G615JMR") || ContainsModel("G615LM") || ContainsModel("G615LR") || ContainsModel("G815LR");
+        return ContainsModel("G614PM") || ContainsModel("G614PP") || ContainsModel("G614PR") || ContainsModel("G512LI") || ContainsModel("G513R") || ContainsModel("G713QM") || ContainsModel("G713PV") || ContainsModel("G513IE") || ContainsModel("G713RC") || ContainsModel("G713IC") || ContainsModel("G713PU") || ContainsModel("G513QM") || ContainsModel("G513QC") || ContainsModel("G531G") || ContainsModel("G615JMR") || ContainsModel("G615LM") || ContainsModel("G615LR") || ContainsModel("G815LR") || ContainsModel("G615LW");
     }
 
     public static bool IsPossible4ZoneRGB()


### PR DESCRIPTION
Hi guys
could you please add support for G615LW (CIS model) since it has per key rgb  (without logo and slash lighting as I understand)
thx


<img width="1966" height="511" alt="image" src="https://github.com/user-attachments/assets/a86b86f7-a83a-4d4e-a6cf-8f456f347438" />
