### PR TITLE
Add optional tray icon temperature display

### DIFF
--- a/app/NativeMethods.cs
+++ b/app/NativeMethods.cs
@@ -13,6 +13,9 @@ public static class NativeMethods
     [DllImport("User32.dll")]
     private static extern bool GetLastInputInfo(ref LASTINPUTINFO plii);
 
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern bool DestroyIcon(IntPtr handle);
+
     public static TimeSpan GetIdleTime()
     {
         LASTINPUTINFO lastInPut = new LASTINPUTINFO();

--- a/app/Properties/Strings.Designer.cs
+++ b/app/Properties/Strings.Designer.cs
@@ -2356,5 +2356,14 @@ namespace GHelper.Properties {
                 return ResourceManager.GetString("Zoom", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Tray Temps.
+        /// </summary>
+        internal static string TrayTemps {
+            get {
+                return ResourceManager.GetString("TrayTemps", resourceCulture);
+            }
+        }
     }
 }

--- a/app/Properties/Strings.resx
+++ b/app/Properties/Strings.resx
@@ -887,4 +887,7 @@ Do you still want to continue?</value>
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="TrayTemps" xml:space="preserve">
+    <value>Tray Temps</value>
+  </data>
 </root>

--- a/app/Settings.Designer.cs
+++ b/app/Settings.Designer.cs
@@ -55,6 +55,7 @@ namespace GHelper
             buttonQuit = new RButton();
             buttonUpdates = new RButton();
             checkStartup = new CheckBox();
+            checkTrayTemps = new CheckBox();
             panelPerformance = new Panel();
             tablePerf = new TableLayoutPanel();
             buttonSilent = new RButton();
@@ -564,7 +565,19 @@ namespace GHelper
             checkStartup.TabIndex = 21;
             checkStartup.Text = Properties.Strings.RunOnStartup;
             checkStartup.UseVisualStyleBackColor = true;
-            // 
+            //
+            // checkTrayTemps
+            //
+            checkTrayTemps.AutoSize = true;
+            checkTrayTemps.Dock = DockStyle.Left;
+            checkTrayTemps.Margin = new Padding(11, 5, 11, 5);
+            checkTrayTemps.Name = "checkTrayTemps";
+            checkTrayTemps.Padding = new Padding(10, 0, 0, 0);
+            checkTrayTemps.Size = new Size(216, 50);
+            checkTrayTemps.TabIndex = 22;
+            checkTrayTemps.Text = Properties.Strings.TrayTemps;
+            checkTrayTemps.UseVisualStyleBackColor = true;
+            //
             // panelPerformance
             // 
             panelPerformance.AccessibleRole = AccessibleRole.Grouping;
@@ -1463,6 +1476,7 @@ namespace GHelper
             // 
             panelStartup.Controls.Add(labelCharge);
             panelStartup.Controls.Add(checkStartup);
+            panelStartup.Controls.Add(checkTrayTemps);
             panelStartup.Dock = DockStyle.Top;
             panelStartup.Location = new Point(11, 1787);
             panelStartup.Margin = new Padding(0);
@@ -2104,6 +2118,7 @@ namespace GHelper
         private Panel panelFooter;
         private RButton buttonQuit;
         private CheckBox checkStartup;
+        private CheckBox checkTrayTemps;
         private Panel panelPerformance;
         private TableLayoutPanel tablePerf;
         private RButton buttonTurbo;

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -40,6 +40,8 @@ namespace GHelper
         public Handheld? handheldForm;
 
         static long lastRefresh;
+        private int trayTempCounter = 0;
+        private IntPtr lastTrayIconHandle = IntPtr.Zero;
         static long lastBatteryRefresh;
         static long lastLostFocus;
 
@@ -89,6 +91,7 @@ namespace GHelper
             checkMatrix.Text = Properties.Strings.TurnOffOnBattery;
             checkMatrixLid.Text = Properties.Strings.DisableOnLidClose;
             checkStartup.Text = Properties.Strings.RunOnStartup;
+            checkTrayTemps.Text = Properties.Strings.TrayTemps;
 
             buttonMatrix.Text = Properties.Strings.PictureGif;
             buttonQuit.Text = Properties.Strings.Quit;
@@ -198,6 +201,9 @@ namespace GHelper
 
             checkStartup.Checked = Startup.IsScheduled();
             checkStartup.CheckedChanged += CheckStartup_CheckedChanged;
+
+            checkTrayTemps.Checked = AppConfig.Get("tray_temps") == 1;
+            checkTrayTemps.CheckedChanged += CheckTrayTemps_CheckedChanged;
 
             labelVersion.Click += LabelVersion_Click;
             labelVersion.ForeColor = Color.FromArgb(128, Color.Gray);
@@ -683,7 +689,7 @@ namespace GHelper
 
         private void SettingsForm_VisibleChanged(object? sender, EventArgs e)
         {
-            sensorTimer.Enabled = this.Visible;
+            sensorTimer.Enabled = this.Visible || AppConfig.Get("tray_temps") == 1;
             if (this.Visible)
             {
                 ScreenControl.InitScreen();
@@ -983,6 +989,24 @@ namespace GHelper
                 Startup.Schedule();
             else
                 Startup.UnSchedule();
+        }
+
+        private void CheckTrayTemps_CheckedChanged(object? sender, EventArgs e)
+        {
+            if (sender is null) return;
+            CheckBox chk = (CheckBox)sender;
+            AppConfig.Set("tray_temps", chk.Checked ? 1 : 0);
+
+            if (!chk.Checked)
+            {
+                if (lastTrayIconHandle != IntPtr.Zero)
+                {
+                    Program.trayIcon?.Icon?.Dispose();
+                    lastTrayIconHandle = IntPtr.Zero;
+                }
+                trayTempCounter = 0;
+                VisualiseIcon();
+            }
         }
 
         private void CheckMatrix_CheckedChanged(object? sender, EventArgs e)
@@ -1511,6 +1535,46 @@ namespace GHelper
             gpuControl.KillGPUApps();
         }
 
+        private void UpdateTrayTempIcon(int cpuTemp, int gpuTemp)
+        {
+            if (Program.trayIcon is null) return;
+
+            bool showGpu = gpuTemp > 0 && (trayTempCounter / 3) % 2 == 1;
+            string text = (showGpu ? gpuTemp : cpuTemp).ToString();
+
+            var iconSize = SystemInformation.SmallIconSize;
+            using var bmp = new Bitmap(iconSize.Width, iconSize.Height);
+            using var g = Graphics.FromImage(bmp);
+            g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.SingleBitPerPixelGridFit;
+
+            float fontScale = text.Length > 2 ? 0.7f : 0.95f;
+            int fontSize = (int)(iconSize.Height * fontScale);
+            bool isDark = CheckSystemDarkModeStatus();
+            using var font = new Font("Segoe UI", fontSize, isDark ? FontStyle.Regular : FontStyle.Bold, GraphicsUnit.Pixel);
+            Color textColor = showGpu ? Color.DodgerBlue : (isDark ? Color.White : Color.Black);
+            using var brush = new SolidBrush(textColor);
+            using var sf = new StringFormat(StringFormat.GenericTypographic);
+            sf.Alignment = StringAlignment.Center;
+            sf.FormatFlags = StringFormatFlags.NoClip | StringFormatFlags.NoWrap;
+
+            float yOffset = iconSize.Height * -0.22f;
+            g.DrawString(text, font, brush, new RectangleF(0, yOffset, iconSize.Width, iconSize.Height), sf);
+
+            IntPtr hIcon = bmp.GetHicon();
+            using var tempIcon = Icon.FromHandle(hIcon);
+            var newIcon = (Icon)tempIcon.Clone();
+            NativeMethods.DestroyIcon(hIcon);
+
+            var oldIcon = Program.trayIcon.Icon;
+            Program.trayIcon.Icon = newIcon;
+
+            if (lastTrayIconHandle != IntPtr.Zero)
+                oldIcon?.Dispose();
+            lastTrayIconHandle = newIcon.Handle;
+
+            trayTempCounter++;
+        }
+
         public async void RefreshSensors(bool force = false)
         {
 
@@ -1568,7 +1632,20 @@ namespace GHelper
                 });
 
 
-            if (Program.trayIcon is not null) Program.trayIcon.Text = trayTip;
+            if (Program.trayIcon is not null)
+            {
+                Program.trayIcon.Text = trayTip;
+
+                var cpu = HardwareControl.cpuTemp;
+                var gpu = HardwareControl.gpuTemp;
+                if (AppConfig.Get("tray_temps") == 1 && cpu > 0)
+                {
+                    UpdateTrayTempIcon(
+                        (int)Math.Round((decimal)cpu),
+                        gpu > 0 ? (int)Math.Round((decimal)gpu) : 0
+                    );
+                }
+            }
 
         }
 
@@ -1818,6 +1895,7 @@ namespace GHelper
         public void VisualiseIcon()
         {
             if (Program.trayIcon is null) return;
+            if (AppConfig.Get("tray_temps") == 1) return;
             int GPUMode = AppConfig.Get("gpu_mode");
             bool isDark = CheckSystemDarkModeStatus();
 

--- a/docs/plans/2026-03-06-tray-temperature-display-design.md
+++ b/docs/plans/2026-03-06-tray-temperature-display-design.md
@@ -1,0 +1,47 @@
+# Tray Temperature Display
+
+## Summary
+
+Replace the static G-Helper tray icon with a dynamically generated icon showing CPU and GPU temperatures, alternating every ~3 seconds. A user setting controls whether this feature is active.
+
+## Display Format
+
+- CPU shown as `C72` (prefix "C" + temperature in °C)
+- GPU shown as `G45` (prefix "G" + temperature in °C)
+- White text on transparent background for both
+- Alternates between CPU and GPU every ~3 sensor ticks (~3s)
+- If GPU temp is unavailable, always show CPU
+
+## UI Toggle
+
+- New checkbox in `panelStartup`, next to "Run on Startup"
+- Label: localized string (e.g. "Tray Temps")
+- Persisted via `AppConfig` with key `"tray_temps"`
+- When disabled: restore static `Properties.Resources.standard` icon
+
+## Implementation Approach
+
+All changes live in existing files — no new classes, files, or timers.
+
+### Icon Generation
+
+- Helper method that creates a 16x16 `Bitmap`
+- Draws short text (`C72` / `G45`) in white, small font
+- Converts to `Icon` via `Icon.FromHandle()`
+- Disposes old generated icon to avoid GDI handle leaks
+
+### Alternating Logic
+
+- Counter incremented each `RefreshSensors()` call (~1s interval)
+- Every ~3 ticks, flip between CPU and GPU display
+- Tracked via a simple integer counter + modulo
+
+### Files to Modify
+
+1. `Settings.Designer.cs` — Add `checkTrayTemps` checkbox to `panelStartup`
+2. `Settings.cs` — Wire checkbox to `AppConfig`, read on init, add icon generation + alternating in `RefreshSensors()`
+3. `Properties/Strings.resx` (+ Designer) — Add localized string for checkbox label
+
+## Future Considerations
+
+- Color-coded temperature thresholds (cool/normal/hot) — left for a future iteration

--- a/docs/plans/2026-03-06-tray-temperature-display.md
+++ b/docs/plans/2026-03-06-tray-temperature-display.md
@@ -1,0 +1,278 @@
+# Tray Temperature Display — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Show CPU/GPU temperatures on the system tray icon, alternating every ~3s, with a user toggle in the settings UI.
+
+**Architecture:** Add a checkbox to `panelStartup` persisted via `AppConfig("tray_temps")`. In `RefreshSensors()`, when enabled, generate a 16x16 icon with temp text (`C72`/`G45`) and assign it to the tray icon. A counter tracks alternation. No new files or timers.
+
+**Tech Stack:** C# / .NET 8 / WinForms, System.Drawing for icon generation
+
+---
+
+### Task 1: Add localized string for the checkbox
+
+**Files:**
+- Modify: `app/Properties/Strings.resx:889` (before closing `</root>` tag)
+- Modify: `app/Properties/Strings.Designer.cs:2358` (before closing brace)
+
+**Step 1: Add resx entry**
+
+In `app/Properties/Strings.resx`, add before the closing `</root>` tag (after line 889):
+
+```xml
+  <data name="TrayTemps" xml:space="preserve">
+    <value>Tray Temps</value>
+  </data>
+```
+
+**Step 2: Add designer property**
+
+In `app/Properties/Strings.Designer.cs`, add before the closing `}` of the class (after line 2358):
+
+```csharp
+
+        /// <summary>
+        ///   Looks up a localized string similar to Tray Temps.
+        /// </summary>
+        internal static string TrayTemps {
+            get {
+                return ResourceManager.GetString("TrayTemps", resourceCulture);
+            }
+        }
+```
+
+**Step 3: Commit**
+
+```bash
+git add app/Properties/Strings.resx app/Properties/Strings.Designer.cs
+git commit -m "feat: add TrayTemps localized string resource"
+```
+
+---
+
+### Task 2: Add checkbox to Settings UI
+
+**Files:**
+- Modify: `app/Settings.Designer.cs:57` (field instantiation area)
+- Modify: `app/Settings.Designer.cs:566` (after checkStartup properties)
+- Modify: `app/Settings.Designer.cs:1465` (panelStartup Controls.Add)
+- Modify: `app/Settings.Designer.cs:2106` (field declarations)
+
+**Step 1: Add field instantiation**
+
+In `app/Settings.Designer.cs`, after line 57 (`checkStartup = new CheckBox();`), add:
+
+```csharp
+            checkTrayTemps = new CheckBox();
+```
+
+**Step 2: Add checkbox properties**
+
+In `app/Settings.Designer.cs`, after line 566 (`checkStartup.UseVisualStyleBackColor = true;`), add:
+
+```csharp
+            //
+            // checkTrayTemps
+            //
+            checkTrayTemps.AutoSize = true;
+            checkTrayTemps.Dock = DockStyle.Left;
+            checkTrayTemps.Margin = new Padding(11, 5, 11, 5);
+            checkTrayTemps.Name = "checkTrayTemps";
+            checkTrayTemps.Padding = new Padding(10, 0, 0, 0);
+            checkTrayTemps.Size = new Size(216, 50);
+            checkTrayTemps.TabIndex = 22;
+            checkTrayTemps.Text = Properties.Strings.TrayTemps;
+            checkTrayTemps.UseVisualStyleBackColor = true;
+```
+
+**Step 3: Add to panelStartup**
+
+In `app/Settings.Designer.cs`, after line 1465 (`panelStartup.Controls.Add(checkStartup);`), add:
+
+```csharp
+            panelStartup.Controls.Add(checkTrayTemps);
+```
+
+Note: Since `checkStartup` is `Dock.Left` and `checkTrayTemps` is also `Dock.Left`, WinForms docks them left-to-right in reverse add order. Adding `checkTrayTemps` after `checkStartup` means it will appear to the right of checkStartup. Verify visually and adjust order if needed.
+
+**Step 4: Add field declaration**
+
+In `app/Settings.Designer.cs`, after line 2106 (`private CheckBox checkStartup;`), add:
+
+```csharp
+        private CheckBox checkTrayTemps;
+```
+
+**Step 5: Commit**
+
+```bash
+git add app/Settings.Designer.cs
+git commit -m "feat: add checkTrayTemps checkbox to panelStartup"
+```
+
+---
+
+### Task 3: Wire checkbox to AppConfig and add icon generation
+
+**Files:**
+- Modify: `app/Settings.cs:91` (text assignment area)
+- Modify: `app/Settings.cs:200` (after checkStartup wiring)
+- Modify: `app/Settings.cs:1571` (in RefreshSensors, tray icon update)
+
+**Step 1: Add text assignment**
+
+In `app/Settings.cs`, after line 91 (`checkStartup.Text = Properties.Strings.RunOnStartup;`), add:
+
+```csharp
+            checkTrayTemps.Text = Properties.Strings.TrayTemps;
+```
+
+**Step 2: Wire checkbox to AppConfig**
+
+In `app/Settings.cs`, after line 200 (`checkStartup.CheckedChanged += CheckStartup_CheckedChanged;`), add:
+
+```csharp
+            checkTrayTemps.Checked = AppConfig.Get("tray_temps") == 1;
+            checkTrayTemps.CheckedChanged += CheckTrayTemps_CheckedChanged;
+```
+
+**Step 3: Add the CheckedChanged handler**
+
+In `app/Settings.cs`, after the `CheckStartup_CheckedChanged` method (around line 985), add:
+
+```csharp
+        private void CheckTrayTemps_CheckedChanged(object? sender, EventArgs e)
+        {
+            if (sender is null) return;
+            CheckBox chk = (CheckBox)sender;
+            AppConfig.Set("tray_temps", chk.Checked ? 1 : 0);
+
+            if (!chk.Checked && Program.trayIcon is not null)
+            {
+                Program.trayIcon.Icon = Properties.Resources.standard;
+            }
+        }
+```
+
+**Step 4: Add alternation counter and icon generation fields**
+
+In `app/Settings.cs`, near the top of the class (around the field declarations, near `lastRefresh`), add:
+
+```csharp
+        private int trayTempCounter = 0;
+        private IntPtr lastTrayIconHandle = IntPtr.Zero;
+```
+
+**Step 5: Add icon generation helper method**
+
+In `app/Settings.cs`, add this method (near `RefreshSensors`):
+
+```csharp
+        private void UpdateTrayTempIcon(int cpuTemp, int gpuTemp)
+        {
+            if (Program.trayIcon is null) return;
+
+            bool showGpu = gpuTemp > 0 && (trayTempCounter / 3) % 2 == 1;
+            string text = showGpu ? $"G{gpuTemp}" : $"C{cpuTemp}";
+
+            using var bmp = new Bitmap(16, 16);
+            using var g = Graphics.FromImage(bmp);
+            g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.SingleBitPerPixelGridFit;
+
+            using var font = new Font("Segoe UI", 6f, FontStyle.Bold);
+            using var brush = new SolidBrush(Color.White);
+
+            var size = g.MeasureString(text, font);
+            float x = (16 - size.Width) / 2;
+            float y = (16 - size.Height) / 2;
+            g.DrawString(text, font, brush, x, y);
+
+            IntPtr hIcon = bmp.GetHicon();
+            Program.trayIcon.Icon = Icon.FromHandle(hIcon);
+
+            if (lastTrayIconHandle != IntPtr.Zero)
+                NativeMethods.DestroyIcon(lastTrayIconHandle);
+            lastTrayIconHandle = hIcon;
+
+            trayTempCounter++;
+        }
+```
+
+**Step 6: Check NativeMethods.DestroyIcon exists**
+
+Verify `NativeMethods.cs` has `DestroyIcon`. If not, add:
+
+```csharp
+[DllImport("user32.dll")]
+public static extern bool DestroyIcon(IntPtr handle);
+```
+
+**Step 7: Call icon generation from RefreshSensors**
+
+In `app/Settings.cs`, replace line 1571:
+
+```csharp
+            if (Program.trayIcon is not null) Program.trayIcon.Text = trayTip;
+```
+
+with:
+
+```csharp
+            if (Program.trayIcon is not null)
+            {
+                Program.trayIcon.Text = trayTip;
+
+                if (AppConfig.Get("tray_temps") == 1 && HardwareControl.cpuTemp > 0)
+                {
+                    UpdateTrayTempIcon(
+                        (int)Math.Round((decimal)HardwareControl.cpuTemp),
+                        HardwareControl.gpuTemp > 0 ? HardwareControl.gpuTemp : 0
+                    );
+                }
+            }
+```
+
+**Step 8: Build and verify**
+
+Run: `dotnet build app/GHelper.sln`
+Expected: Build succeeds with no errors.
+
+**Step 9: Commit**
+
+```bash
+git add app/Settings.cs app/NativeMethods.cs
+git commit -m "feat: tray temperature display with alternating CPU/GPU icons"
+```
+
+---
+
+### Task 4: Manual testing
+
+**Step 1: Run the application**
+
+Run G-Helper and verify:
+- The "Tray Temps" checkbox appears next to "Run on Startup"
+- When unchecked: static icon displays as before
+- When checked: tray icon shows `C##` alternating with `G##` every ~3 seconds
+- When GPU temp is unavailable: only `C##` is shown
+- Tooltip still shows full CPU/GPU/battery info on hover
+- Unchecking restores the static icon immediately
+
+**Step 2: Commit final state**
+
+If any adjustments were needed, commit them:
+
+```bash
+git add -u
+git commit -m "fix: tray temp display adjustments from manual testing"
+```
+
+---
+
+### Notes
+
+- `DestroyIcon` is needed to avoid GDI handle leaks since `Bitmap.GetHicon()` creates an unmanaged icon handle
+- Font size 6f on 16x16 should fit 3 characters (`G99`). If text is clipped, try 5.5f
+- The `trayTempCounter / 3 % 2` pattern gives ~3 second alternation at 1s sensor interval
+- `HardwareControl.cpuTemp` and `gpuTemp` are `float` — cast to `int` for display


### PR DESCRIPTION
## Summary

- Adds a "Tray Temps" checkbox to the settings panel (next to "Run on Startup")
- When enabled, the system tray icon shows CPU and GPU temperatures as numbers, alternating every 3 seconds
- CPU temperature is shown in white (dark taskbar) or black (light taskbar)
- GPU temperature is shown in blue (DodgerBlue) to distinguish it from CPU
- When disabled, the original mode-aware icon is restored

## How it works

The feature hooks into the existing `RefreshSensors` loop. On each tick, if enabled, it generates a small bitmap with the current temperature, converts it to an icon, and assigns it to the tray. The icon size is queried from `SystemInformation.SmallIconSize` so it renders correctly at any DPI scaling. Text is drawn with GDI+ using `SingleBitPerPixelGridFit` to avoid anti-aliasing artifacts on transparent backgrounds.

The setting is persisted via `AppConfig` under the key `tray_temps`. The sensor timer stays active when the form is hidden if tray temps are enabled, so the display keeps updating in the background.

Native icon handles are managed carefully to avoid GDI leaks. Each generated icon is cloned so the managed `Icon` object owns its handle, and the previous icon is disposed on the next cycle. `DestroyIcon` is called via P/Invoke to clean up the native handle from `GetHicon`.

A guard was added to `VisualiseIcon` so that mode changes (eco, standard, ultimate) don't overwrite the temperature icon while the feature is active.

## Files changed

- `NativeMethods.cs` - Added `DestroyIcon` P/Invoke
- `Properties/Strings.resx` and `Strings.Designer.cs` - Added "Tray Temps" localized string
- `Settings.Designer.cs` - Added checkbox to the startup panel
- `Settings.cs` - Checkbox wiring, icon generation, sensor integration, timer fix, VisualiseIcon guard

## Test plan

- [ ] Enable "Tray Temps" and verify the icon shows the current CPU temperature
- [ ] After about 3 seconds, verify it switches to GPU temperature in blue
- [ ] If no discrete GPU is present, verify it stays on CPU only
- [ ] Toggle the checkbox off and verify the correct mode icon is restored
- [ ] Close the settings window and verify the temperature keeps updating
- [ ] Switch between dark and light system theme and verify text color adapts
- [ ] Verify no icon flickering or GDI handle growth over extended use