### PR TITLE
Add battery optimization reminder popup and auto optimization logic

### DIFF
--- a/app/Battery/BatteryOptimizationService.cs
+++ b/app/Battery/BatteryOptimizationService.cs
@@ -1,0 +1,216 @@
+using GHelper.Display;
+using GHelper.Helpers;
+using GHelper.Mode;
+
+namespace GHelper.Battery
+{
+    public static class BatteryOptimizationService
+    {
+        private static long _lastCheckTimestamp;
+
+        public static List<string> GetUnoptimizedSettings()
+        {
+            var issues = new List<string>();
+
+            // 1. Performance mode is Turbo
+            try
+            {
+                if (Modes.GetCurrentBase() == AsusACPI.PerformanceTurbo)
+                    issues.Add("Performance: Turbo");
+            }
+            catch (Exception ex) { Logger.WriteLine($"BatteryOptCheck Turbo: {ex.Message}"); }
+
+            // 2. Discrete GPU active without auto-switching
+            try
+            {
+                if (Program.acpi.DeviceGet(AsusACPI.GPUEco) >= 0
+                    && !AppConfig.Is("gpu_auto")
+                    && AppConfig.Get("gpu_mode") != AsusACPI.GPUModeEco)
+                {
+                    issues.Add("Discrete GPU active");
+                }
+            }
+            catch (Exception ex) { Logger.WriteLine($"BatteryOptCheck GPU: {ex.Message}"); }
+
+            // 3. High refresh rate without auto-switching
+            try
+            {
+                if (!AppConfig.Is("screen_auto"))
+                {
+                    var laptopScreen = ScreenNative.FindLaptopScreen();
+                    if (laptopScreen != null)
+                    {
+                        int rate = ScreenNative.GetRefreshRate(laptopScreen);
+                        if (rate > 60)
+                            issues.Add($"Display: {rate}Hz");
+                    }
+                }
+            }
+            catch (Exception ex) { Logger.WriteLine($"BatteryOptCheck Screen: {ex.Message}"); }
+
+            // 4. CPU boost enabled for current mode
+            try
+            {
+                if (AppConfig.GetMode("auto_boost") > 0)
+                    issues.Add("CPU boost enabled");
+            }
+            catch (Exception ex) { Logger.WriteLine($"BatteryOptCheck Boost: {ex.Message}"); }
+
+            // 5. Anime Matrix/Slash running without auto
+            try
+            {
+                if ((AppConfig.IsAnimeMatrix() || AppConfig.IsSlash())
+                    && !AppConfig.Is("matrix_auto")
+                    && AppConfig.Get("matrix_running") > 0)
+                {
+                    issues.Add("Anime Matrix active");
+                }
+            }
+            catch (Exception ex) { Logger.WriteLine($"BatteryOptCheck Matrix: {ex.Message}"); }
+
+            // 6. Overdrive enabled
+            try
+            {
+                if (Program.acpi.IsOverdriveSupported()
+                    && !AppConfig.IsNoOverdrive()
+                    && Program.acpi.DeviceGet(AsusACPI.ScreenOverdrive) == 1)
+                {
+                    issues.Add("Screen overdrive on");
+                }
+            }
+            catch (Exception ex) { Logger.WriteLine($"BatteryOptCheck Overdrive: {ex.Message}"); }
+
+            // 7. Keyboard backlight has no timeout
+            try
+            {
+                if (AppConfig.Get("keyboard_timeout") <= 0)
+                    issues.Add("Keyboard backlight always on");
+            }
+            catch (Exception ex) { Logger.WriteLine($"BatteryOptCheck Keyboard: {ex.Message}"); }
+
+            return issues;
+        }
+
+        public static void ApplyBatteryOptimizations()
+        {
+            try
+            {
+                // 1. Switch to Silent mode (mode 2) or user's configured battery mode
+                int batteryMode = AppConfig.Get("performance_0", 2);
+                if (batteryMode < 0) batteryMode = 2;
+                Program.modeControl.SetPerformanceMode(batteryMode);
+            }
+            catch (Exception ex) { Logger.WriteLine($"BatteryOpt Mode: {ex.Message}"); }
+
+            try
+            {
+                // 2. Enable GPU auto-switching and switch to Eco
+                if (Program.acpi.DeviceGet(AsusACPI.GPUEco) >= 0)
+                {
+                    AppConfig.Set("gpu_auto", 1);
+                    Program.gpuControl.AutoGPUMode();
+                }
+            }
+            catch (Exception ex) { Logger.WriteLine($"BatteryOpt GPU: {ex.Message}"); }
+
+            try
+            {
+                // 3. Enable screen auto-switching (sets 60Hz on battery)
+                AppConfig.Set("screen_auto", 1);
+                ScreenControl.AutoScreen();
+            }
+            catch (Exception ex) { Logger.WriteLine($"BatteryOpt Screen: {ex.Message}"); }
+
+            try
+            {
+                // 4. Disable CPU boost
+                AppConfig.SetMode("auto_boost", 0);
+                PowerNative.SetCPUBoost(0);
+            }
+            catch (Exception ex) { Logger.WriteLine($"BatteryOpt Boost: {ex.Message}"); }
+
+            try
+            {
+                // 5. Enable matrix auto (if device has Anime Matrix/Slash)
+                if (AppConfig.IsAnimeMatrix() || AppConfig.IsSlash())
+                    AppConfig.Set("matrix_auto", 1);
+            }
+            catch (Exception ex) { Logger.WriteLine($"BatteryOpt Matrix: {ex.Message}"); }
+
+            try
+            {
+                // 6. Enable no_overdrive (if supported)
+                if (Program.acpi.IsOverdriveSupported())
+                {
+                    AppConfig.Set("no_overdrive", 1);
+                    ScreenControl.AutoScreen(true);
+                }
+            }
+            catch (Exception ex) { Logger.WriteLine($"BatteryOpt Overdrive: {ex.Message}"); }
+
+            try
+            {
+                // 7. Set keyboard timeout to 60s if currently 0
+                if (AppConfig.Get("keyboard_timeout") <= 0)
+                    AppConfig.Set("keyboard_timeout", 60);
+            }
+            catch (Exception ex) { Logger.WriteLine($"BatteryOpt Keyboard: {ex.Message}"); }
+
+            // Refresh settings UI
+            try
+            {
+                Program.settingsForm.Invoke(delegate
+                {
+                    Program.settingsForm.VisualiseGPUMode();
+                    Program.settingsForm.ShowMode(Modes.GetCurrent());
+                });
+            }
+            catch (Exception ex) { Logger.WriteLine($"BatteryOpt UI Refresh: {ex.Message}"); }
+        }
+
+        public static void CheckAndNotify(bool isStartup = false)
+        {
+            try
+            {
+                // Guard: feature disabled
+                if (!AppConfig.IsNotFalse("battery_remind")) return;
+
+                // Guard: plugged in
+                if (SystemInformation.PowerStatus.PowerLineStatus == PowerLineStatus.Online) return;
+
+                // Guard: power events disabled
+                if (!isStartup && AppConfig.Is("disable_power_event")) return;
+
+                // Debounce: 10 seconds
+                long now = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+                if (Math.Abs(now - _lastCheckTimestamp) < 10000) return;
+                _lastCheckTimestamp = now;
+
+                var issues = GetUnoptimizedSettings();
+                if (issues.Count == 0) return;
+
+                Logger.WriteLine($"Battery optimization: {issues.Count} issues found");
+
+                if (AppConfig.Is("battery_auto_optimize"))
+                {
+                    ApplyBatteryOptimizations();
+                    Program.toast.RunToast("Switched to battery-optimized mode");
+                    return;
+                }
+
+                // Show reminder on UI thread
+                if (isStartup)
+                    Thread.Sleep(2000);
+
+                Program.settingsForm.Invoke(delegate
+                {
+                    BatteryReminderForm.ShowReminder(issues);
+                });
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteLine($"BatteryOptCheck: {ex.Message}");
+            }
+        }
+    }
+}

--- a/app/Battery/BatteryOptimizationService.cs
+++ b/app/Battery/BatteryOptimizationService.cs
@@ -16,7 +16,7 @@ namespace GHelper.Battery
             try
             {
                 if (Modes.GetCurrentBase() == AsusACPI.PerformanceTurbo)
-                    issues.Add("Performance: Turbo");
+                    issues.Add(Properties.Strings.BatteryIssuePerformanceTurbo);
             }
             catch (Exception ex) { Logger.WriteLine($"BatteryOptCheck Turbo: {ex.Message}"); }
 
@@ -27,7 +27,7 @@ namespace GHelper.Battery
                     && !AppConfig.Is("gpu_auto")
                     && AppConfig.Get("gpu_mode") != AsusACPI.GPUModeEco)
                 {
-                    issues.Add("Discrete GPU active");
+                    issues.Add(Properties.Strings.BatteryIssueDiscreteGPU);
                 }
             }
             catch (Exception ex) { Logger.WriteLine($"BatteryOptCheck GPU: {ex.Message}"); }
@@ -42,7 +42,7 @@ namespace GHelper.Battery
                     {
                         int rate = ScreenNative.GetRefreshRate(laptopScreen);
                         if (rate > 60)
-                            issues.Add($"Display: {rate}Hz");
+                            issues.Add(string.Format(Properties.Strings.BatteryIssueDisplayRate, rate));
                     }
                 }
             }
@@ -52,7 +52,7 @@ namespace GHelper.Battery
             try
             {
                 if (AppConfig.GetMode("auto_boost") > 0)
-                    issues.Add("CPU boost enabled");
+                    issues.Add(Properties.Strings.BatteryIssueCPUBoost);
             }
             catch (Exception ex) { Logger.WriteLine($"BatteryOptCheck Boost: {ex.Message}"); }
 
@@ -63,7 +63,7 @@ namespace GHelper.Battery
                     && !AppConfig.Is("matrix_auto")
                     && AppConfig.Get("matrix_running") > 0)
                 {
-                    issues.Add("Anime Matrix active");
+                    issues.Add(Properties.Strings.BatteryIssueAnimeMatrix);
                 }
             }
             catch (Exception ex) { Logger.WriteLine($"BatteryOptCheck Matrix: {ex.Message}"); }
@@ -75,7 +75,7 @@ namespace GHelper.Battery
                     && !AppConfig.IsNoOverdrive()
                     && Program.acpi.DeviceGet(AsusACPI.ScreenOverdrive) == 1)
                 {
-                    issues.Add("Screen overdrive on");
+                    issues.Add(Properties.Strings.BatteryIssueOverdrive);
                 }
             }
             catch (Exception ex) { Logger.WriteLine($"BatteryOptCheck Overdrive: {ex.Message}"); }
@@ -84,7 +84,7 @@ namespace GHelper.Battery
             try
             {
                 if (AppConfig.Get("keyboard_timeout") <= 0)
-                    issues.Add("Keyboard backlight always on");
+                    issues.Add(Properties.Strings.BatteryIssueKeyboardBacklight);
             }
             catch (Exception ex) { Logger.WriteLine($"BatteryOptCheck Keyboard: {ex.Message}"); }
 
@@ -194,7 +194,7 @@ namespace GHelper.Battery
                 if (AppConfig.Is("battery_auto_optimize"))
                 {
                     ApplyBatteryOptimizations();
-                    Program.toast.RunToast("Switched to battery-optimized mode");
+                    Program.toast.RunToast(Properties.Strings.BatteryOptimizedToast);
                     return;
                 }
 

--- a/app/Battery/BatteryReminderForm.Designer.cs
+++ b/app/Battery/BatteryReminderForm.Designer.cs
@@ -61,7 +61,7 @@ namespace GHelper.Battery
             labelTitle.Name = "labelTitle";
             labelTitle.Size = new Size(472, 45);
             labelTitle.TabIndex = 1;
-            labelTitle.Text = "Battery Optimization Reminder";
+            labelTitle.Text = "Battery Optimization";
             // 
             // labelSubtitle
             // 
@@ -124,7 +124,7 @@ namespace GHelper.Battery
             buttonOptimize.Secondary = false;
             buttonOptimize.Size = new Size(332, 50);
             buttonOptimize.TabIndex = 7;
-            buttonOptimize.Text = "Optimize for Battery";
+            buttonOptimize.Text = "Optimize for battery";
             // 
             // buttonDismiss
             // 

--- a/app/Battery/BatteryReminderForm.Designer.cs
+++ b/app/Battery/BatteryReminderForm.Designer.cs
@@ -1,0 +1,180 @@
+using GHelper.UI;
+
+namespace GHelper.Battery
+{
+    partial class BatteryReminderForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            labelClose = new Label();
+            labelTitle = new Label();
+            labelSubtitle = new Label();
+            labelIssue1 = new Label();
+            labelIssue2 = new Label();
+            labelIssue3 = new Label();
+            checkAutoOptimize = new CheckBox();
+            buttonOptimize = new RButton();
+            buttonDismiss = new RButton();
+            SuspendLayout();
+            // 
+            // labelClose
+            // 
+            labelClose.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            labelClose.AutoSize = true;
+            labelClose.Cursor = Cursors.Hand;
+            labelClose.Font = new Font("Segoe UI", 10F, FontStyle.Bold);
+            labelClose.Location = new Point(613, 6);
+            labelClose.Name = "labelClose";
+            labelClose.Size = new Size(40, 37);
+            labelClose.TabIndex = 0;
+            labelClose.Text = "✕";
+            // 
+            // labelTitle
+            // 
+            labelTitle.AutoSize = true;
+            labelTitle.Font = new Font("Segoe UI Semibold", 12F);
+            labelTitle.Location = new Point(28, 20);
+            labelTitle.Name = "labelTitle";
+            labelTitle.Size = new Size(472, 45);
+            labelTitle.TabIndex = 1;
+            labelTitle.Text = "Battery Optimization Reminder";
+            // 
+            // labelSubtitle
+            // 
+            labelSubtitle.AutoSize = true;
+            labelSubtitle.Font = new Font("Segoe UI", 9.5F);
+            labelSubtitle.Location = new Point(28, 71);
+            labelSubtitle.Name = "labelSubtitle";
+            labelSubtitle.Size = new Size(539, 36);
+            labelSubtitle.TabIndex = 2;
+            labelSubtitle.Text = "Your current settings may drain battery faster:";
+            // 
+            // labelIssue1
+            // 
+            labelIssue1.AutoSize = true;
+            labelIssue1.Font = new Font("Segoe UI", 9.5F);
+            labelIssue1.Location = new Point(42, 110);
+            labelIssue1.Name = "labelIssue1";
+            labelIssue1.Size = new Size(0, 36);
+            labelIssue1.TabIndex = 3;
+            // 
+            // labelIssue2
+            // 
+            labelIssue2.AutoSize = true;
+            labelIssue2.Font = new Font("Segoe UI", 9.5F);
+            labelIssue2.Location = new Point(42, 141);
+            labelIssue2.Name = "labelIssue2";
+            labelIssue2.Size = new Size(0, 36);
+            labelIssue2.TabIndex = 4;
+            // 
+            // labelIssue3
+            // 
+            labelIssue3.AutoSize = true;
+            labelIssue3.Font = new Font("Segoe UI", 9.5F);
+            labelIssue3.Location = new Point(42, 172);
+            labelIssue3.Name = "labelIssue3";
+            labelIssue3.Size = new Size(0, 36);
+            labelIssue3.TabIndex = 5;
+            // 
+            // checkAutoOptimize
+            // 
+            checkAutoOptimize.AutoSize = true;
+            checkAutoOptimize.FlatStyle = FlatStyle.Flat;
+            checkAutoOptimize.Font = new Font("Segoe UI", 9.5F);
+            checkAutoOptimize.Location = new Point(42, 210);
+            checkAutoOptimize.Name = "checkAutoOptimize";
+            checkAutoOptimize.Padding = new Padding(4, 2, 4, 2);
+            checkAutoOptimize.Size = new Size(367, 44);
+            checkAutoOptimize.TabIndex = 6;
+            checkAutoOptimize.Text = "Always switch automatically";
+            // 
+            // buttonOptimize
+            // 
+            buttonOptimize.Activated = false;
+            buttonOptimize.BorderColor = Color.Transparent;
+            buttonOptimize.BorderRadius = 20;
+            buttonOptimize.FlatStyle = FlatStyle.Flat;
+            buttonOptimize.Font = new Font("Segoe UI Semibold", 10F);
+            buttonOptimize.Location = new Point(11, 258);
+            buttonOptimize.Name = "buttonOptimize";
+            buttonOptimize.Secondary = false;
+            buttonOptimize.Size = new Size(332, 50);
+            buttonOptimize.TabIndex = 7;
+            buttonOptimize.Text = "Optimize for Battery";
+            // 
+            // buttonDismiss
+            // 
+            buttonDismiss.Activated = false;
+            buttonDismiss.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            buttonDismiss.BorderColor = Color.Transparent;
+            buttonDismiss.BorderRadius = 20;
+            buttonDismiss.FlatStyle = FlatStyle.Flat;
+            buttonDismiss.Font = new Font("Segoe UI", 10F);
+            buttonDismiss.Location = new Point(376, 258);
+            buttonDismiss.Name = "buttonDismiss";
+            buttonDismiss.Secondary = true;
+            buttonDismiss.Size = new Size(274, 50);
+            buttonDismiss.TabIndex = 8;
+            buttonDismiss.Text = "Don't remind me";
+            // 
+            // BatteryReminderForm
+            // 
+            AutoScaleDimensions = new SizeF(192F, 192F);
+            AutoScaleMode = AutoScaleMode.Dpi;
+            ClientSize = new Size(661, 340);
+            Controls.Add(labelClose);
+            Controls.Add(labelTitle);
+            Controls.Add(labelSubtitle);
+            Controls.Add(labelIssue1);
+            Controls.Add(labelIssue2);
+            Controls.Add(labelIssue3);
+            Controls.Add(checkAutoOptimize);
+            Controls.Add(buttonOptimize);
+            Controls.Add(buttonDismiss);
+            FormBorderStyle = FormBorderStyle.None;
+            Name = "BatteryReminderForm";
+            Padding = new Padding(8);
+            ShowInTaskbar = false;
+            StartPosition = FormStartPosition.Manual;
+            TopMost = true;
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private Label labelClose;
+        private Label labelTitle;
+        private Label labelSubtitle;
+        private Label labelIssue1;
+        private Label labelIssue2;
+        private Label labelIssue3;
+        private CheckBox checkAutoOptimize;
+        private RButton buttonOptimize;
+        private RButton buttonDismiss;
+    }
+}

--- a/app/Battery/BatteryReminderForm.cs
+++ b/app/Battery/BatteryReminderForm.cs
@@ -54,6 +54,12 @@ namespace GHelper.Battery
 
             Region = CreateRoundedRegion(ClientRectangle, 20);
 
+            labelTitle.Text = Properties.Strings.BatteryOptimization;
+            labelSubtitle.Text = Properties.Strings.BatteryOptimizationSubtitle;
+            checkAutoOptimize.Text = Properties.Strings.BatteryAutoSwitch;
+            buttonOptimize.Text = Properties.Strings.BatteryOptimizeButton;
+            buttonDismiss.Text = Properties.Strings.BatteryDontRemind;
+
             PopulateIssues(issues);
             PositionOnScreen();
 
@@ -126,7 +132,7 @@ namespace GHelper.Battery
             Task.Run(() =>
             {
                 BatteryOptimizationService.ApplyBatteryOptimizations();
-                Program.toast.RunToast("Switched to battery-optimized mode");
+                Program.toast.RunToast(Properties.Strings.BatteryOptimizedToast);
             });
         }
 

--- a/app/Battery/BatteryReminderForm.cs
+++ b/app/Battery/BatteryReminderForm.cs
@@ -4,11 +4,11 @@ using System.Drawing.Drawing2D;
 
 namespace GHelper.Battery
 {
-    public partial class BatteryReminderForm : RForm
+    public partial class BatteryReminderForm : Form
     {
         private static BatteryReminderForm? _instance;
 
-        private readonly System.Windows.Forms.Timer _autoHideTimer;
+        private System.Windows.Forms.Timer? _autoHideTimer;
         private bool _mouseHovering;
 
         public static void ShowReminder(List<string> issues)
@@ -27,19 +27,28 @@ namespace GHelper.Battery
             }
         }
 
-        private BatteryReminderForm(List<string> issues)
+        public BatteryReminderForm()
         {
             InitializeComponent();
+        }
 
+        private BatteryReminderForm(List<string> issues)
+        {
             TopMost = true;
             Opacity = 0.95;
 
-            InitTheme();
             BackColor = RForm.formBack;
             ForeColor = RForm.foreMain;
 
+            buttonOptimize.BackColor = RForm.buttonMain;
+            buttonOptimize.ForeColor = RForm.foreMain;
+            buttonOptimize.FlatAppearance.BorderColor = RForm.borderMain;
             buttonOptimize.Activated = true;
             buttonOptimize.BorderColor = RForm.borderMain;
+
+            buttonDismiss.BackColor = RForm.buttonSecond;
+            buttonDismiss.ForeColor = RForm.foreMain;
+            buttonDismiss.FlatAppearance.BorderColor = RForm.borderMain;
             buttonDismiss.Activated = true;
             buttonDismiss.BorderColor = RForm.borderMain;
 
@@ -73,8 +82,8 @@ namespace GHelper.Battery
 
             FormClosed += (s, e) =>
             {
-                _autoHideTimer.Stop();
-                _autoHideTimer.Dispose();
+                _autoHideTimer?.Stop();
+                _autoHideTimer?.Dispose();
                 if (_instance == this) _instance = null;
             };
         }

--- a/app/Battery/BatteryReminderForm.cs
+++ b/app/Battery/BatteryReminderForm.cs
@@ -1,0 +1,164 @@
+using GHelper.Helpers;
+using GHelper.UI;
+using System.Drawing.Drawing2D;
+
+namespace GHelper.Battery
+{
+    public partial class BatteryReminderForm : RForm
+    {
+        private static BatteryReminderForm? _instance;
+
+        private readonly System.Windows.Forms.Timer _autoHideTimer;
+        private bool _mouseHovering;
+
+        public static void ShowReminder(List<string> issues)
+        {
+            _instance?.Close();
+            _instance = new BatteryReminderForm(issues);
+            _instance.Show();
+        }
+
+        public static void DismissIfShowing()
+        {
+            if (_instance != null && !_instance.IsDisposed)
+            {
+                _instance.Close();
+                _instance = null;
+            }
+        }
+
+        private BatteryReminderForm(List<string> issues)
+        {
+            InitializeComponent();
+
+            TopMost = true;
+            Opacity = 0.95;
+
+            InitTheme();
+            BackColor = RForm.formBack;
+            ForeColor = RForm.foreMain;
+
+            buttonOptimize.Activated = true;
+            buttonOptimize.BorderColor = RForm.borderMain;
+            buttonDismiss.Activated = true;
+            buttonDismiss.BorderColor = RForm.borderMain;
+
+            Region = CreateRoundedRegion(ClientRectangle, 20);
+
+            PopulateIssues(issues);
+            PositionOnScreen();
+
+            // Wire up events
+            labelClose.Click += (s, e) => Close();
+            buttonOptimize.Click += ButtonOptimize_Click;
+            buttonDismiss.Click += ButtonDismiss_Click;
+
+            // Auto-hide timer
+            int timeout = AppConfig.Get("battery_remind_timeout", 30);
+            timeout = Math.Clamp(timeout, 2, 120);
+
+            _autoHideTimer = new System.Windows.Forms.Timer();
+            _autoHideTimer.Interval = timeout * 1000;
+            _autoHideTimer.Tick += (s, e) =>
+            {
+                if (!_mouseHovering) Close();
+            };
+            _autoHideTimer.Start();
+
+            // Track mouse hover on form and all controls
+            MouseEnter += (s, e) => _mouseHovering = true;
+            MouseLeave += (s, e) => _mouseHovering = false;
+            foreach (Control control in Controls)
+                HookMouseHover(control);
+
+            FormClosed += (s, e) =>
+            {
+                _autoHideTimer.Stop();
+                _autoHideTimer.Dispose();
+                if (_instance == this) _instance = null;
+            };
+        }
+
+        private void PopulateIssues(List<string> issues)
+        {
+            Label[] labels = { labelIssue1, labelIssue2, labelIssue3 };
+
+            for (int i = 0; i < labels.Length; i++)
+            {
+                if (i < issues.Count)
+                {
+                    labels[i].Text = (i == 2 && issues.Count > 3)
+                        ? "..."
+                        : "\u2022  " + issues[i];
+                    labels[i].Visible = true;
+                }
+                else
+                {
+                    labels[i].Visible = false;
+                }
+            }
+        }
+
+        private void PositionOnScreen()
+        {
+            var screen = Screen.PrimaryScreen ?? Screen.FromControl(this);
+            var workArea = screen.WorkingArea;
+            Left = workArea.Right - Width - 20;
+            Top = workArea.Bottom - Height - 20;
+        }
+
+        private void ButtonOptimize_Click(object? sender, EventArgs e)
+        {
+            if (checkAutoOptimize.Checked)
+                AppConfig.Set("battery_auto_optimize", 1);
+
+            Close();
+
+            Task.Run(() =>
+            {
+                BatteryOptimizationService.ApplyBatteryOptimizations();
+                Program.toast.RunToast("Switched to battery-optimized mode");
+            });
+        }
+
+        private void ButtonDismiss_Click(object? sender, EventArgs e)
+        {
+            AppConfig.Set("battery_remind", 0);
+            Close();
+        }
+
+        private void HookMouseHover(Control control)
+        {
+            control.MouseEnter += (s, e) => _mouseHovering = true;
+            control.MouseLeave += (s, e) => _mouseHovering = false;
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+
+            using var pen = new Pen(RForm.borderMain, 1);
+            using var path = CreateRoundedPath(new Rectangle(0, 0, Width - 1, Height - 1), 20);
+            e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;
+            e.Graphics.DrawPath(pen, path);
+        }
+
+        private static Region CreateRoundedRegion(Rectangle bounds, int radius)
+        {
+            using var path = CreateRoundedPath(bounds, radius);
+            return new Region(path);
+        }
+
+        private static GraphicsPath CreateRoundedPath(Rectangle bounds, int radius)
+        {
+            int diameter = radius * 2;
+            var path = new GraphicsPath();
+            path.AddArc(bounds.X, bounds.Y, diameter, diameter, 180, 90);
+            path.AddArc(bounds.Right - diameter, bounds.Y, diameter, diameter, 270, 90);
+            path.AddArc(bounds.Right - diameter, bounds.Bottom - diameter, diameter, diameter, 0, 90);
+            path.AddArc(bounds.X, bounds.Bottom - diameter, diameter, diameter, 90, 90);
+            path.CloseFigure();
+            return path;
+        }
+    }
+}

--- a/app/Battery/BatteryReminderForm.resx
+++ b/app/Battery/BatteryReminderForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/app/Extra.Designer.cs
+++ b/app/Extra.Designer.cs
@@ -1212,9 +1212,9 @@ namespace GHelper
             panelSettings.Controls.Add(checkGPUFix);
             panelSettings.Controls.Add(checkNVPlatform);
             panelSettings.Controls.Add(checkStatusLed);
-            panelSettings.Controls.Add(panelReminderTimeout);
             panelSettings.Controls.Add(checkBatteryAutoOptimize);
             panelSettings.Controls.Add(checkBatteryRemind);
+            panelSettings.Controls.Add(panelReminderTimeout);
             panelSettings.Controls.Add(labelBattery);
             panelSettings.Controls.Add(checkPerKeyRGB);
             panelSettings.Dock = DockStyle.Top;
@@ -1390,30 +1390,29 @@ namespace GHelper
             //
             // panelReminderTimeout
             //
-            panelReminderTimeout.AutoSize = true;
-            panelReminderTimeout.Dock = DockStyle.Top;
             panelReminderTimeout.Controls.Add(numericReminderTimeout);
             panelReminderTimeout.Controls.Add(labelReminderTimeout);
+            panelReminderTimeout.Dock = DockStyle.Top;
             panelReminderTimeout.Name = "panelReminderTimeout";
-            panelReminderTimeout.Padding = new Padding(3);
-            panelReminderTimeout.Size = new Size(917, 36);
+            panelReminderTimeout.Size = new Size(917, 46);
             //
             // labelReminderTimeout
             //
-            labelReminderTimeout.AutoSize = true;
-            labelReminderTimeout.Dock = DockStyle.Left;
+            labelReminderTimeout.Location = new Point(3, 5);
+            labelReminderTimeout.Margin = new Padding(5, 0, 5, 0);
             labelReminderTimeout.Name = "labelReminderTimeout";
-            labelReminderTimeout.Padding = new Padding(3, 6, 3, 3);
+            labelReminderTimeout.Size = new Size(613, 43);
             labelReminderTimeout.Text = "Reminder duration (seconds)";
             //
             // numericReminderTimeout
             //
-            numericReminderTimeout.Dock = DockStyle.Left;
+            numericReminderTimeout.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            numericReminderTimeout.Location = new Point(789, 5);
             numericReminderTimeout.Minimum = 2;
             numericReminderTimeout.Maximum = 120;
             numericReminderTimeout.Value = 30;
             numericReminderTimeout.Name = "numericReminderTimeout";
-            numericReminderTimeout.Size = new Size(60, 30);
+            numericReminderTimeout.Size = new Size(139, 39);
             //
             // checkPerKeyRGB
             //

--- a/app/Extra.Designer.cs
+++ b/app/Extra.Designer.cs
@@ -1373,7 +1373,7 @@ namespace GHelper
             checkBatteryRemind.Padding = new Padding(3);
             checkBatteryRemind.Size = new Size(917, 42);
             checkBatteryRemind.TabIndex = 20;
-            checkBatteryRemind.Text = "Show battery optimization reminders";
+            checkBatteryRemind.Text = "Show battery optimization notifications";
             checkBatteryRemind.UseVisualStyleBackColor = true;
             //
             // checkBatteryAutoOptimize

--- a/app/Extra.Designer.cs
+++ b/app/Extra.Designer.cs
@@ -1402,7 +1402,7 @@ namespace GHelper
             labelReminderTimeout.Margin = new Padding(5, 0, 5, 0);
             labelReminderTimeout.Name = "labelReminderTimeout";
             labelReminderTimeout.Size = new Size(613, 43);
-            labelReminderTimeout.Text = "Reminder duration (seconds)";
+            labelReminderTimeout.Text = "Notification duration (seconds)";
             //
             // numericReminderTimeout
             //

--- a/app/Extra.Designer.cs
+++ b/app/Extra.Designer.cs
@@ -115,6 +115,12 @@ namespace GHelper
             checkBWIcon = new CheckBox();
             checkTopmost = new CheckBox();
             checkNoOverdrive = new CheckBox();
+            labelBattery = new Label();
+            checkBatteryRemind = new CheckBox();
+            checkBatteryAutoOptimize = new CheckBox();
+            panelReminderTimeout = new Panel();
+            labelReminderTimeout = new Label();
+            numericReminderTimeout = new NumericUpDown();
             checkBootSound = new CheckBox();
             checkUSBC = new CheckBox();
             checkGpuApps = new CheckBox();
@@ -167,6 +173,8 @@ namespace GHelper
             ((System.ComponentModel.ISupportInitialize)pictureLog).BeginInit();
             ((System.ComponentModel.ISupportInitialize)pictureSettings).BeginInit();
             panelSettings.SuspendLayout();
+            panelReminderTimeout.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)numericReminderTimeout).BeginInit();
             panelPower.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)numericHibernateAfter).BeginInit();
             ((System.ComponentModel.ISupportInitialize)pictureHibernate).BeginInit();
@@ -1204,6 +1212,10 @@ namespace GHelper
             panelSettings.Controls.Add(checkGPUFix);
             panelSettings.Controls.Add(checkNVPlatform);
             panelSettings.Controls.Add(checkStatusLed);
+            panelSettings.Controls.Add(panelReminderTimeout);
+            panelSettings.Controls.Add(checkBatteryAutoOptimize);
+            panelSettings.Controls.Add(checkBatteryRemind);
+            panelSettings.Controls.Add(labelBattery);
             panelSettings.Controls.Add(checkPerKeyRGB);
             panelSettings.Dock = DockStyle.Top;
             panelSettings.Location = new Point(15, 1252);
@@ -1342,8 +1354,69 @@ namespace GHelper
             checkStatusLed.UseVisualStyleBackColor = true;
             checkStatusLed.Visible = false;
             // 
+            // labelBattery
+            //
+            labelBattery.AutoSize = true;
+            labelBattery.Dock = DockStyle.Top;
+            labelBattery.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
+            labelBattery.Name = "labelBattery";
+            labelBattery.Padding = new Padding(3, 10, 3, 3);
+            labelBattery.Size = new Size(917, 32);
+            labelBattery.Text = "Battery";
+            //
+            // checkBatteryRemind
+            //
+            checkBatteryRemind.AutoSize = true;
+            checkBatteryRemind.Dock = DockStyle.Top;
+            checkBatteryRemind.Margin = new Padding(5, 3, 5, 3);
+            checkBatteryRemind.Name = "checkBatteryRemind";
+            checkBatteryRemind.Padding = new Padding(3);
+            checkBatteryRemind.Size = new Size(917, 42);
+            checkBatteryRemind.TabIndex = 20;
+            checkBatteryRemind.Text = "Show battery optimization reminders";
+            checkBatteryRemind.UseVisualStyleBackColor = true;
+            //
+            // checkBatteryAutoOptimize
+            //
+            checkBatteryAutoOptimize.AutoSize = true;
+            checkBatteryAutoOptimize.Dock = DockStyle.Top;
+            checkBatteryAutoOptimize.Margin = new Padding(5, 3, 5, 3);
+            checkBatteryAutoOptimize.Name = "checkBatteryAutoOptimize";
+            checkBatteryAutoOptimize.Padding = new Padding(3);
+            checkBatteryAutoOptimize.Size = new Size(917, 42);
+            checkBatteryAutoOptimize.TabIndex = 21;
+            checkBatteryAutoOptimize.Text = "Auto-switch to optimized mode on battery";
+            checkBatteryAutoOptimize.UseVisualStyleBackColor = true;
+            //
+            // panelReminderTimeout
+            //
+            panelReminderTimeout.AutoSize = true;
+            panelReminderTimeout.Dock = DockStyle.Top;
+            panelReminderTimeout.Controls.Add(numericReminderTimeout);
+            panelReminderTimeout.Controls.Add(labelReminderTimeout);
+            panelReminderTimeout.Name = "panelReminderTimeout";
+            panelReminderTimeout.Padding = new Padding(3);
+            panelReminderTimeout.Size = new Size(917, 36);
+            //
+            // labelReminderTimeout
+            //
+            labelReminderTimeout.AutoSize = true;
+            labelReminderTimeout.Dock = DockStyle.Left;
+            labelReminderTimeout.Name = "labelReminderTimeout";
+            labelReminderTimeout.Padding = new Padding(3, 6, 3, 3);
+            labelReminderTimeout.Text = "Reminder duration (seconds)";
+            //
+            // numericReminderTimeout
+            //
+            numericReminderTimeout.Dock = DockStyle.Left;
+            numericReminderTimeout.Minimum = 2;
+            numericReminderTimeout.Maximum = 120;
+            numericReminderTimeout.Value = 30;
+            numericReminderTimeout.Name = "numericReminderTimeout";
+            numericReminderTimeout.Size = new Size(60, 30);
+            //
             // checkPerKeyRGB
-            // 
+            //
             checkPerKeyRGB.AutoSize = true;
             checkPerKeyRGB.Dock = DockStyle.Top;
             checkPerKeyRGB.Location = new Point(21, 5);
@@ -1721,6 +1794,9 @@ namespace GHelper
             ((System.ComponentModel.ISupportInitialize)pictureSettings).EndInit();
             panelSettings.ResumeLayout(false);
             panelSettings.PerformLayout();
+            panelReminderTimeout.ResumeLayout(false);
+            panelReminderTimeout.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)numericReminderTimeout).EndInit();
             panelPower.ResumeLayout(false);
             panelPower.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)numericHibernateAfter).EndInit();
@@ -1858,5 +1934,11 @@ namespace GHelper
         private RComboBox comboOptimalBrightness;
         private PictureBox pictureOptimalBrightness;
         private Label labelOptimalBrightness;
+        private Label labelBattery;
+        private CheckBox checkBatteryRemind;
+        private CheckBox checkBatteryAutoOptimize;
+        private Panel panelReminderTimeout;
+        private Label labelReminderTimeout;
+        private NumericUpDown numericReminderTimeout;
     }
 }

--- a/app/Extra.cs
+++ b/app/Extra.cs
@@ -480,6 +480,15 @@ namespace GHelper
             toolTip.SetToolTip(checkAutoToggleClamshellMode, "Disable sleep on lid close when plugged in and external monitor is connected");
             toolTip.SetToolTip(checkNVPlatform, "Stops NVIDIA services when the discrete GPU is disabled\nand restarts them automatically when the GPU is enabled");
 
+            // Battery optimization settings
+            checkBatteryRemind.Checked = AppConfig.IsNotFalse("battery_remind");
+            checkBatteryAutoOptimize.Checked = AppConfig.Is("battery_auto_optimize");
+            numericReminderTimeout.Value = Math.Clamp(AppConfig.Get("battery_remind_timeout", 30), 2, 120);
+
+            checkBatteryRemind.CheckedChanged += CheckBatteryRemind_CheckedChanged;
+            checkBatteryAutoOptimize.CheckedChanged += CheckBatteryAutoOptimize_CheckedChanged;
+            numericReminderTimeout.ValueChanged += NumericReminderTimeout_ValueChanged;
+
             InitCores();
             InitServices();
             InitHibernate();
@@ -853,6 +862,21 @@ namespace GHelper
                 ClamshellModeControl.DisableClamshellMode();
             }
 
+        }
+
+        private void CheckBatteryRemind_CheckedChanged(object? sender, EventArgs e)
+        {
+            AppConfig.Set("battery_remind", checkBatteryRemind.Checked ? 1 : 0);
+        }
+
+        private void CheckBatteryAutoOptimize_CheckedChanged(object? sender, EventArgs e)
+        {
+            AppConfig.Set("battery_auto_optimize", checkBatteryAutoOptimize.Checked ? 1 : 0);
+        }
+
+        private void NumericReminderTimeout_ValueChanged(object? sender, EventArgs e)
+        {
+            AppConfig.Set("battery_remind_timeout", (int)numericReminderTimeout.Value);
         }
 
         private void panelAPU_Paint(object sender, PaintEventArgs e)

--- a/app/Extra.cs
+++ b/app/Extra.cs
@@ -481,6 +481,10 @@ namespace GHelper
             toolTip.SetToolTip(checkNVPlatform, "Stops NVIDIA services when the discrete GPU is disabled\nand restarts them automatically when the GPU is enabled");
 
             // Battery optimization settings
+            labelBattery.Text = Properties.Strings.BatterySectionHeader;
+            checkBatteryRemind.Text = Properties.Strings.BatteryShowNotifications;
+            checkBatteryAutoOptimize.Text = Properties.Strings.BatteryAutoOptimize;
+
             checkBatteryRemind.Checked = AppConfig.IsNotFalse("battery_remind");
             checkBatteryAutoOptimize.Checked = AppConfig.Is("battery_auto_optimize");
             numericReminderTimeout.Value = Math.Clamp(AppConfig.Get("battery_remind_timeout", 30), 2, 120);

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -311,6 +311,8 @@ namespace GHelper
             ScreenControl.InitMiniled();
             VisualControl.InitBrightness();
 
+            Task.Run(() => Battery.BatteryOptimizationService.CheckAndNotify(init));
+
             return true;
         }
 

--- a/app/Properties/Strings.Designer.cs
+++ b/app/Properties/Strings.Designer.cs
@@ -2356,5 +2356,149 @@ namespace GHelper.Properties {
                 return ResourceManager.GetString("Zoom", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Battery Optimization.
+        /// </summary>
+        internal static string BatteryOptimization {
+            get {
+                return ResourceManager.GetString("BatteryOptimization", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Your current settings may drain battery faster:.
+        /// </summary>
+        internal static string BatteryOptimizationSubtitle {
+            get {
+                return ResourceManager.GetString("BatteryOptimizationSubtitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Always switch automatically.
+        /// </summary>
+        internal static string BatteryAutoSwitch {
+            get {
+                return ResourceManager.GetString("BatteryAutoSwitch", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Optimize for battery.
+        /// </summary>
+        internal static string BatteryOptimizeButton {
+            get {
+                return ResourceManager.GetString("BatteryOptimizeButton", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Don&apos;t remind me.
+        /// </summary>
+        internal static string BatteryDontRemind {
+            get {
+                return ResourceManager.GetString("BatteryDontRemind", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Switched to battery-optimized mode.
+        /// </summary>
+        internal static string BatteryOptimizedToast {
+            get {
+                return ResourceManager.GetString("BatteryOptimizedToast", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Performance: Turbo.
+        /// </summary>
+        internal static string BatteryIssuePerformanceTurbo {
+            get {
+                return ResourceManager.GetString("BatteryIssuePerformanceTurbo", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Discrete GPU active.
+        /// </summary>
+        internal static string BatteryIssueDiscreteGPU {
+            get {
+                return ResourceManager.GetString("BatteryIssueDiscreteGPU", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Display: {0}Hz.
+        /// </summary>
+        internal static string BatteryIssueDisplayRate {
+            get {
+                return ResourceManager.GetString("BatteryIssueDisplayRate", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to CPU boost enabled.
+        /// </summary>
+        internal static string BatteryIssueCPUBoost {
+            get {
+                return ResourceManager.GetString("BatteryIssueCPUBoost", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Anime Matrix active.
+        /// </summary>
+        internal static string BatteryIssueAnimeMatrix {
+            get {
+                return ResourceManager.GetString("BatteryIssueAnimeMatrix", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Screen overdrive on.
+        /// </summary>
+        internal static string BatteryIssueOverdrive {
+            get {
+                return ResourceManager.GetString("BatteryIssueOverdrive", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Keyboard backlight always on.
+        /// </summary>
+        internal static string BatteryIssueKeyboardBacklight {
+            get {
+                return ResourceManager.GetString("BatteryIssueKeyboardBacklight", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Show battery optimization notifications.
+        /// </summary>
+        internal static string BatteryShowNotifications {
+            get {
+                return ResourceManager.GetString("BatteryShowNotifications", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Auto-switch to optimized mode on battery.
+        /// </summary>
+        internal static string BatteryAutoOptimize {
+            get {
+                return ResourceManager.GetString("BatteryAutoOptimize", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Battery.
+        /// </summary>
+        internal static string BatterySectionHeader {
+            get {
+                return ResourceManager.GetString("BatterySectionHeader", resourceCulture);
+            }
+        }
     }
 }

--- a/app/Properties/Strings.ar.resx
+++ b/app/Properties/Strings.ar.resx
@@ -887,4 +887,52 @@
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>التبديل التلقائي إلى الوضع المحسّن عند استخدام البطارية</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>التبديل تلقائياً دائماً</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>لا تذكرني</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix نشط</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>تعزيز CPU مفعّل</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>GPU المنفصل نشط</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>الشاشة: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>إضاءة لوحة المفاتيح مفعّلة دائماً</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>تسريع الشاشة مفعّل</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>الأداء: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>تحسين البطارية</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>إعداداتك الحالية قد تستنزف البطارية بشكل أسرع:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>تحسين لاستخدام البطارية</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>تم التبديل إلى وضع تحسين البطارية</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>البطارية</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>إظهار إشعارات تحسين البطارية</value>
+  </data>
 </root>

--- a/app/Properties/Strings.da.resx
+++ b/app/Properties/Strings.da.resx
@@ -887,4 +887,52 @@ Vil du stadig fortsætte?</value>
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Skift automatisk til optimeret tilstand på batteri</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Skift altid automatisk</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>Påmind mig ikke</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix aktiv</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>CPU boost aktiveret</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>Diskret GPU aktiv</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Skærm: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Tastaturbelysning altid tændt</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Skærm overdrive tændt</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Ydeevne: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Batterioptimering</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>Dine nuværende indstillinger kan dræne batteriet hurtigere:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Optimer til batteri</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>Skiftet til batterioptimeret tilstand</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Batteri</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Vis batterioptimeringsnotifikationer</value>
+  </data>
 </root>

--- a/app/Properties/Strings.de.resx
+++ b/app/Properties/Strings.de.resx
@@ -887,4 +887,52 @@ Trotzdem fortfahren?</value>
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Automatisch in optimierten Modus wechseln im Akkubetrieb</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Immer automatisch wechseln</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>Nicht erinnern</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix aktiv</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>CPU-Boost aktiviert</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>Dedizierte GPU aktiv</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Anzeige: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Tastaturbeleuchtung immer an</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Bildschirm-Overdrive an</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Leistung: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Akkuoptimierung</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>Ihre aktuellen Einstellungen können den Akku schneller entladen:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Für Akkubetrieb optimieren</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>In akkuoptimierten Modus gewechselt</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Akku</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Akkuoptimierungs-Benachrichtigungen anzeigen</value>
+  </data>
 </root>

--- a/app/Properties/Strings.es.resx
+++ b/app/Properties/Strings.es.resx
@@ -887,4 +887,52 @@
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Modo zona</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Cambiar automáticamente al modo optimizado con batería</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Cambiar siempre automáticamente</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>No recordar</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix activo</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>Turbo de CPU activado</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>GPU dedicada activa</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Pantalla: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Retroiluminación del teclado siempre encendida</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Sobremarcha de pantalla activada</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Rendimiento: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Optimización de batería</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>Tu configuración actual puede agotar la batería más rápido:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Optimizar para batería</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>Cambiado al modo optimizado de batería</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Batería</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Mostrar notificaciones de optimización de batería</value>
+  </data>
 </root>

--- a/app/Properties/Strings.fr.resx
+++ b/app/Properties/Strings.fr.resx
@@ -887,4 +887,52 @@ Voulez-vous continuer ?</value>
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Basculer automatiquement en mode optimisé sur batterie</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Toujours basculer automatiquement</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>Ne pas me rappeler</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix actif</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>Boost CPU activé</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>GPU dédiée active</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Écran : {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Rétroéclairage du clavier toujours allumé</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Overdrive écran activé</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Performance : Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Optimisation de la batterie</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>Vos paramètres actuels peuvent décharger la batterie plus vite :</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Optimiser pour la batterie</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>Mode optimisé pour la batterie activé</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Batterie</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Afficher les notifications d'optimisation de la batterie</value>
+  </data>
 </root>

--- a/app/Properties/Strings.hu.resx
+++ b/app/Properties/Strings.hu.resx
@@ -887,4 +887,52 @@ Folytatni szeretnéd?</value>
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Automatikus váltás optimalizált módra akkumulátoron</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Mindig automatikusan váltson</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>Ne emlékeztess</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix aktív</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>CPU boost engedélyezve</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>Dedikált GPU aktív</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Kijelző: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Billentyűzet háttérvilágítás mindig bekapcsolva</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Képernyő overdrive bekapcsolva</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Teljesítmény: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Akkumulátor optimalizálás</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>A jelenlegi beállítások gyorsabban meríthetik az akkumulátort:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Optimalizálás akkumulátorra</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>Átváltva akkumulátor-optimalizált módra</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Akkumulátor</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Akkumulátor optimalizálási értesítések megjelenítése</value>
+  </data>
 </root>

--- a/app/Properties/Strings.id.resx
+++ b/app/Properties/Strings.id.resx
@@ -887,4 +887,52 @@ Apakah Anda masih ingin melanjutkan?</value>
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Beralih otomatis ke mode optimal saat menggunakan baterai</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Selalu beralih otomatis</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>Jangan ingatkan saya</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix aktif</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>CPU boost diaktifkan</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>GPU diskrit aktif</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Layar: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Lampu latar keyboard selalu menyala</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Overdrive layar aktif</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Performa: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Optimasi Baterai</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>Pengaturan Anda saat ini dapat menguras baterai lebih cepat:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Optimalkan untuk baterai</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>Beralih ke mode hemat baterai</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Baterai</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Tampilkan notifikasi optimasi baterai</value>
+  </data>
 </root>

--- a/app/Properties/Strings.it.resx
+++ b/app/Properties/Strings.it.resx
@@ -887,4 +887,52 @@ Sei sicuro di voler continuare?</value>
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Passa automaticamente alla modalità ottimizzata a batteria</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Cambia sempre automaticamente</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>Non ricordarmelo</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix attivo</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>Boost CPU attivato</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>GPU dedicata attiva</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Schermo: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Retroilluminazione tastiera sempre accesa</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Overdrive schermo attivo</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Prestazioni: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Ottimizzazione batteria</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>Le impostazioni attuali potrebbero scaricare la batteria più velocemente:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Ottimizza per la batteria</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>Passato alla modalità ottimizzata per la batteria</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Batteria</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Mostra notifiche di ottimizzazione batteria</value>
+  </data>
 </root>

--- a/app/Properties/Strings.ja.resx
+++ b/app/Properties/Strings.ja.resx
@@ -887,4 +887,52 @@
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zoneモード</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>バッテリー使用時に最適化モードへ自動切替</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>常に自動切替</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>今後表示しない</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrixがオン</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>CPUブーストが有効</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>ディスクリートGPUがオン</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>ディスプレイ: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>キーボードバックライトが常時オン</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>画面オーバードライブがオン</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>パフォーマンス: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>バッテリー最適化</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>現在の設定ではバッテリーの消耗が早くなる可能性があります:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>バッテリー向けに最適化</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>バッテリー最適化モードに切り替えました</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>バッテリー</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>バッテリー最適化の通知を表示</value>
+  </data>
 </root>

--- a/app/Properties/Strings.ko.resx
+++ b/app/Properties/Strings.ko.resx
@@ -887,4 +887,52 @@
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>배터리 사용 시 최적화 모드로 자동 전환</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>항상 자동으로 전환</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>다시 알리지 않음</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix 활성화됨</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>CPU 부스트 활성화됨</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>외장 GPU 활성화됨</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>디스플레이: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>키보드 백라이트 항상 켜짐</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>화면 오버드라이브 켜짐</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>성능: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>배터리 최적화</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>현재 설정이 배터리를 더 빨리 소모할 수 있습니다:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>배터리에 최적화</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>배터리 최적화 모드로 전환됨</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>배터리</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>배터리 최적화 알림 표시</value>
+  </data>
 </root>

--- a/app/Properties/Strings.lt.resx
+++ b/app/Properties/Strings.lt.resx
@@ -887,4 +887,52 @@ Vis tiek norite tęsti?</value>
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Automatiškai perjungti į optimizuotą režimą naudojant bateriją</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Visada perjungti automatiškai</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>Nepriminti</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix aktyvus</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>CPU pagreitinimas įjungtas</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>Atskiras GPU aktyvus</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Ekranas: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Klaviatūros apšvietimas visada įjungtas</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Ekrano overdrive įjungtas</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Našumas: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Baterijos optimizavimas</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>Jūsų dabartiniai nustatymai gali greičiau iškrauti bateriją:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Optimizuoti baterijai</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>Perjungta į baterijos optimizavimo režimą</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Baterija</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Rodyti baterijos optimizavimo pranešimus</value>
+  </data>
 </root>

--- a/app/Properties/Strings.pl.resx
+++ b/app/Properties/Strings.pl.resx
@@ -887,4 +887,52 @@ Nadal chcesz kontynuować?</value>
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Automatyczne przełączanie na tryb zoptymalizowany na baterii</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Zawsze przełączaj automatycznie</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>Nie przypominaj</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix aktywny</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>Boost CPU włączony</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>Dedykowany GPU aktywny</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Ekran: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Podświetlenie klawiatury zawsze włączone</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Overdrive ekranu włączony</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Wydajność: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Optymalizacja baterii</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>Twoje obecne ustawienia mogą szybciej rozładowywać baterię:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Optymalizuj dla baterii</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>Przełączono na tryb zoptymalizowany dla baterii</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Bateria</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Pokazuj powiadomienia o optymalizacji baterii</value>
+  </data>
 </root>

--- a/app/Properties/Strings.pt-BR.resx
+++ b/app/Properties/Strings.pt-BR.resx
@@ -887,4 +887,52 @@ Ainda quer continuar?</value>
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Alternar automaticamente para o modo otimizado na bateria</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Sempre alternar automaticamente</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>Não me lembrar</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix ativo</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>Turbo da CPU ativado</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>GPU dedicada ativa</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Tela: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Luz de fundo do teclado sempre ligada</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Overdrive da tela ativado</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Desempenho: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Otimização de bateria</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>Suas configurações atuais podem descarregar a bateria mais rápido:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Otimizar para bateria</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>Alternado para o modo otimizado de bateria</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Bateria</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Mostrar notificações de otimização de bateria</value>
+  </data>
 </root>

--- a/app/Properties/Strings.pt-PT.resx
+++ b/app/Properties/Strings.pt-PT.resx
@@ -887,4 +887,52 @@ Quer prosseguir?</value>
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Mudar automaticamente para o modo otimizado com bateria</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Mudar sempre automaticamente</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>Não me lembrar</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix ativo</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>Turbo do CPU ativado</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>GPU dedicada ativa</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Ecrã: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Retroiluminação do teclado sempre ligada</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Overdrive do ecrã ativado</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Desempenho: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Otimização de bateria</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>As suas definições atuais podem descarregar a bateria mais rapidamente:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Otimizar para bateria</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>Mudado para o modo otimizado de bateria</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Bateria</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Mostrar notificações de otimização de bateria</value>
+  </data>
 </root>

--- a/app/Properties/Strings.resx
+++ b/app/Properties/Strings.resx
@@ -887,4 +887,53 @@ Do you still want to continue?</value>
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Battery Optimization</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>Your current settings may drain battery faster:</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Always switch automatically</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Optimize for battery</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>Don't remind me</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>Switched to battery-optimized mode</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Performance: Turbo</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>Discrete GPU active</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Display: {0}Hz</value>
+    <comment>{0} is the display refresh rate in Hz</comment>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>CPU boost enabled</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix active</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Screen overdrive on</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Keyboard backlight always on</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Show battery optimization notifications</value>
+  </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Auto-switch to optimized mode on battery</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Battery</value>
+  </data>
 </root>

--- a/app/Properties/Strings.ro.resx
+++ b/app/Properties/Strings.ro.resx
@@ -887,4 +887,52 @@
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Comutare automată la modul optimizat pe baterie</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Comută întotdeauna automat</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>Nu îmi aminti</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix activ</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>Boost CPU activat</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>GPU dedicat activ</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Afișaj: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Iluminare tastatură mereu activă</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Overdrive ecran activat</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Performanță: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Optimizare baterie</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>Setările actuale pot descărca bateria mai repede:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Optimizează pentru baterie</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>Comutat la modul optimizat pentru baterie</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Baterie</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Afișează notificările de optimizare a bateriei</value>
+  </data>
 </root>

--- a/app/Properties/Strings.tr.resx
+++ b/app/Properties/Strings.tr.resx
@@ -887,4 +887,52 @@ Yine de devam etmek istiyor musunuz?</value>
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Pilde otomatik olarak optimize edilmiş moda geç</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Her zaman otomatik geçiş yap</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>Hatırlatma</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix etkin</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>CPU boost etkin</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>Ayrık GPU etkin</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Ekran: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Klavye aydınlatması her zaman açık</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Ekran overdrive açık</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Performans: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Pil Optimizasyonu</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>Mevcut ayarlarınız pili daha hızlı tüketebilir:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Pil için optimize et</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>Pil için optimize edilmiş moda geçildi</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Pil</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Pil optimizasyonu bildirimlerini göster</value>
+  </data>
 </root>

--- a/app/Properties/Strings.uk.resx
+++ b/app/Properties/Strings.uk.resx
@@ -887,4 +887,52 @@
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Автоматичне переключення в оптимізований режим при роботі від батареї</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Завжди переключати автоматично</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>Не нагадувати</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix активний</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>Прискорення CPU увімкнено</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>Дискретний GPU активний</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Дисплей: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Підсвітка клавіатури завжди увімкнена</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Овердрайв екрану увімкнено</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Продуктивність: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Оптимізація батареї</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>Ваші поточні налаштування можуть швидше розряджати батарею:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Оптимізувати для батареї</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>Переключено на режим оптимізації батареї</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Батарея</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Показувати сповіщення про оптимізацію батареї</value>
+  </data>
 </root>

--- a/app/Properties/Strings.vi.resx
+++ b/app/Properties/Strings.vi.resx
@@ -887,4 +887,52 @@ Bạn có muốn tiếp tục không?</value>
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone Mode</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>Tự động chuyển sang chế độ tối ưu khi dùng pin</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>Luôn tự động chuyển</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>Không nhắc lại</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix đang bật</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>Tăng cường CPU đang bật</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>GPU rời đang hoạt động</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>Màn hình: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>Đèn nền bàn phím luôn bật</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>Overdrive màn hình đang bật</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>Hiệu năng: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>Tối ưu hóa pin</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>Cài đặt hiện tại của bạn có thể tiêu hao pin nhanh hơn:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>Tối ưu cho pin</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>Đã chuyển sang chế độ tối ưu pin</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>Pin</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>Hiển thị thông báo tối ưu hóa pin</value>
+  </data>
 </root>

--- a/app/Properties/Strings.zh-CN.resx
+++ b/app/Properties/Strings.zh-CN.resx
@@ -887,4 +887,52 @@
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone 模式</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>使用电池时自动切换到优化模式</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>始终自动切换</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>不再提醒</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix 已启用</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>CPU加速已启用</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>独立显卡已启用</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>显示: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>键盘背光常亮</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>屏幕过驱动已开启</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>性能: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>电池优化</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>当前设置可能会加快电池消耗:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>优化电池续航</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>已切换到电池优化模式</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>电池</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>显示电池优化通知</value>
+  </data>
 </root>

--- a/app/Properties/Strings.zh-TW.resx
+++ b/app/Properties/Strings.zh-TW.resx
@@ -887,4 +887,52 @@
   <data name="MouseZoneMode" xml:space="preserve">
     <value>Zone 模式</value>
   </data>
+  <data name="BatteryAutoOptimize" xml:space="preserve">
+    <value>使用電池時自動切換至最佳化模式</value>
+  </data>
+  <data name="BatteryAutoSwitch" xml:space="preserve">
+    <value>總是自動切換</value>
+  </data>
+  <data name="BatteryDontRemind" xml:space="preserve">
+    <value>不再提醒</value>
+  </data>
+  <data name="BatteryIssueAnimeMatrix" xml:space="preserve">
+    <value>Anime Matrix 已啟用</value>
+  </data>
+  <data name="BatteryIssueCPUBoost" xml:space="preserve">
+    <value>CPU加速已啟用</value>
+  </data>
+  <data name="BatteryIssueDiscreteGPU" xml:space="preserve">
+    <value>獨立顯示卡已啟用</value>
+  </data>
+  <data name="BatteryIssueDisplayRate" xml:space="preserve">
+    <value>螢幕: {0}Hz</value>
+  </data>
+  <data name="BatteryIssueKeyboardBacklight" xml:space="preserve">
+    <value>鍵盤背光常亮</value>
+  </data>
+  <data name="BatteryIssueOverdrive" xml:space="preserve">
+    <value>螢幕過驅動已開啟</value>
+  </data>
+  <data name="BatteryIssuePerformanceTurbo" xml:space="preserve">
+    <value>效能: Turbo</value>
+  </data>
+  <data name="BatteryOptimization" xml:space="preserve">
+    <value>電池最佳化</value>
+  </data>
+  <data name="BatteryOptimizationSubtitle" xml:space="preserve">
+    <value>目前的設定可能會加快電池消耗:</value>
+  </data>
+  <data name="BatteryOptimizeButton" xml:space="preserve">
+    <value>最佳化電池續航</value>
+  </data>
+  <data name="BatteryOptimizedToast" xml:space="preserve">
+    <value>已切換至電池最佳化模式</value>
+  </data>
+  <data name="BatterySectionHeader" xml:space="preserve">
+    <value>電池</value>
+  </data>
+  <data name="BatteryShowNotifications" xml:space="preserve">
+    <value>顯示電池最佳化通知</value>
+  </data>
 </root>

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -1599,6 +1599,7 @@ namespace GHelper
 
         public void ShowMode(int mode)
         {
+            Battery.BatteryReminderForm.DismissIfShowing();
             if (InvokeRequired)
                 Invoke(delegate
                 {
@@ -1761,6 +1762,7 @@ namespace GHelper
 
         public void VisualiseGPUMode(int GPUMode = -1)
         {
+            Battery.BatteryReminderForm.DismissIfShowing();
             if (AppConfig.IsAlly())
             {
                 tableGPU.Visible = false;


### PR DESCRIPTION
Detects suboptimal settings (high performance mode, dedicated GPU active, high refresh rate, etc) when unplugging from AC power (also checking on app launch if on battery power) and show a toast-style popup offering to switch to battery optimized settings. 

  - BatteryOptimizationService: scans current settings against battery-optimal baselines, applies optimizations on request
  - BatteryReminderForm: popup, auto-hide timer, hover-to-pause, and "always auto-optimize" checkbox, can be disabled on popup or in settings
  - Integrates via Program.cs on power source change events
 
Tested on Zephyrus G14 (2024)

<img width="800" height="592" alt="Screenshot 2026-03-21 071521" src="https://github.com/user-attachments/assets/3ac10df9-9bf3-4d37-960c-484b95bc83ef" />


<img width="990" height="444" alt="Screenshot 2026-03-21 085852" src="https://github.com/user-attachments/assets/e3003cd9-51c1-4e56-8228-1c0b72dad602" />
