### PR TITLE
Robust barrel/usb-c/battery power source detection

### DIFF
--- a/app/Gpu/GPUModeControl.cs
+++ b/app/Gpu/GPUModeControl.cs
@@ -203,20 +203,9 @@ namespace GHelper.Gpu
 
         }
 
-        public static bool IsPlugged()
-        {
-            if (SystemInformation.PowerStatus.PowerLineStatus != PowerLineStatus.Online) return false;
-            if (!AppConfig.Is("optimized_usbc")) return true;
-
-            if (AppConfig.ContainsModel("FA507")) Thread.Sleep(1000);
-
-            int chargerMode = Program.acpi.DeviceGet(AsusACPI.ChargerMode);
-            Logger.WriteLine("ChargerStatus: " + chargerMode);
-
-            if (chargerMode <= 0) return true;
-            return (chargerMode & AsusACPI.ChargerBarrel) > 0;
-
-        }
+        public static bool IsPlugged() =>
+            Program.currentSource == Program.PowerSource.Barrel ||
+            (Program.currentSource == Program.PowerSource.USBC && !AppConfig.Is("optimized_usbc"));
 
         public bool AutoGPUMode(bool optimized = false, int delay = 0)
         {

--- a/app/Input/InputDispatcher.cs
+++ b/app/Input/InputDispatcher.cs
@@ -1304,6 +1304,9 @@ namespace GHelper.Input
             int EventID = int.Parse(e.NewEvent["EventID"].ToString());
             Logger.WriteLine("WMI event " + EventID);
             if (AppConfig.NoWMI()) return;
+
+            if (EventID == 123) Program.OnChargerEvent();
+
             HandleEvent(EventID);
         }
     }

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -39,8 +39,6 @@ namespace GHelper
 
         public static InputDispatcher? inputDispatcher;
 
-        private static PowerLineStatus isPlugged = SystemInformation.PowerStatus.PowerLineStatus;
-
         // The main entry point for the application
         public static void Main(string[] args)
         {
@@ -153,6 +151,8 @@ namespace GHelper
             XGM.Init();
 
             SetAutoModes(init: true);
+
+            powerSettleTimer.Elapsed += OnPowerSettled;
 
             // Subscribing for system power change events
             SystemEvents.PowerModeChanged += SystemEvents_PowerModeChanged;
@@ -289,8 +289,8 @@ namespace GHelper
             if (Math.Abs(DateTimeOffset.Now.ToUnixTimeMilliseconds() - lastAuto) < skipDelay) return false;
             lastAuto = DateTimeOffset.Now.ToUnixTimeMilliseconds();
 
-            isPlugged = SystemInformation.PowerStatus.PowerLineStatus;
-            Logger.WriteLine("AutoSetting for " + isPlugged.ToString());
+            currentSource = ReadPowerSource();
+            Logger.WriteLine("AutoSetting for " + SystemInformation.PowerStatus.PowerLineStatus.ToString());
 
             BatteryControl.AutoBattery(init);
             if (init) InputDispatcher.InitScreenpad();
@@ -328,6 +328,43 @@ namespace GHelper
             return true;
         }
 
+        public enum PowerSource { Battery, USBC, Barrel }
+
+        public static PowerSource currentSource = PowerSource.Battery;
+        private static readonly System.Timers.Timer powerSettleTimer = new() { AutoReset = false };
+
+        public static PowerSource ReadPowerSource()
+        {
+            if (SystemInformation.PowerStatus.PowerLineStatus != PowerLineStatus.Online)
+                return PowerSource.Battery;
+
+            int chargerMode = acpi?.DeviceGet(AsusACPI.ChargerMode) ?? 0;
+            if (chargerMode > 0 && (chargerMode & AsusACPI.ChargerBarrel) == 0)
+                return PowerSource.USBC;
+
+            return PowerSource.Barrel;
+        }
+
+        public static void SchedulePowerCheck()
+        {
+            if (AppConfig.Is("disable_power_event")) return;
+            powerSettleTimer.Interval = Math.Max(AppConfig.Get("charger_delay"), 2000);
+            powerSettleTimer.Stop();
+            powerSettleTimer.Start();
+        }
+
+        private static void OnPowerSettled(object? sender, System.Timers.ElapsedEventArgs e)
+        {
+            PowerSource source = ReadPowerSource();
+            if (source == currentSource) return;
+
+            Logger.WriteLine($"Power source: {currentSource} -> {source}");
+            currentSource = source;
+            SetAutoModes(powerChanged: true);
+        }
+
+        public static void OnChargerEvent() => SchedulePowerCheck();
+
         private static void SystemEvents_PowerModeChanged(object sender, PowerModeChangedEventArgs e)
         {
             if (e.Mode == PowerModes.Suspend)
@@ -335,22 +372,11 @@ namespace GHelper
                 Logger.WriteLine("Power Mode Changed:" + e.Mode.ToString());
                 modeControl.ShutdownReset();
                 InputDispatcher.ShutdownStatusLed();
+                return;
             }
 
-            if (SystemInformation.PowerStatus.PowerLineStatus == isPlugged) return;
             Logger.WriteLine($"Power Mode {e.Mode}: {SystemInformation.PowerStatus.PowerLineStatus}");
-            
-            if (AppConfig.Is("disable_power_event")) return;
-
-            int delay = AppConfig.Get("charger_delay");
-            if (delay > 0)
-            {
-                Logger.WriteLine($"Charger Delay: {delay}");
-                Thread.Sleep(delay);
-                if (SystemInformation.PowerStatus.PowerLineStatus == isPlugged) return;
-            }
-
-            SetAutoModes(powerChanged: true);
+            SchedulePowerCheck();
         }
 
         public static void SettingsToggle(bool checkForFocus = true, bool trayClick = false)


### PR DESCRIPTION
- App would now detect 3 power source types : barrel charger / usb-c charger / battery (instead barrel / battery before)
- On each power source change app would wait extra 2 seconds before applying mode and other settings
- Helps with Optimized mode when switching between usb-c <-> barrel charger https://github.com/seerge/g-helper/issues/5112
