### PR TITLE
Fix battery slider snapping to unsupported charge limits

### DIFF
--- a/app/Battery/BatteryControl.cs
+++ b/app/Battery/BatteryControl.cs
@@ -62,18 +62,38 @@ namespace GHelper.Battery
             }
         }
 
+        private static int ClampLimit(int limit)
+        {
+            if (AppConfig.IsChargeLimit6080())
+            {
+                if (limit > 85) return 100;
+                if (limit >= 80) return 80;
+                if (limit < 60) return 60;
+            }
+            return limit;
+        }
+
+        public static int[]? GetSupportedLimits(int step = 1)
+        {
+            if (step <= 0) step = 1;
+            var candidates = Enumerable.Range(0, (100 - 40) / step + 1)
+                .Select(i => 40 + i * step)
+                .ToArray();
+            var stops = candidates
+                .Select(ClampLimit)
+                .Distinct()
+                .OrderBy(x => x)
+                .ToArray();
+            return stops.Length < candidates.Length ? stops : null;
+        }
+
         public static void SetBatteryChargeLimit(int setLimit = -1)
         {
             int limit = setLimit;
             if (limit < 0) limit = AppConfig.Get("charge_limit");
             if (limit < 40 || limit > 100) return;
 
-            if (AppConfig.IsChargeLimit6080())
-            {
-                if (limit > 85) limit = 100;
-                else if (limit >= 80) limit = 80;
-                else if (limit < 60) limit = 60;
-            }
+            limit = ClampLimit(limit);
 
             if (setLimit > 0) SetAsusChargeLimit(limit);
 

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -243,6 +243,8 @@ namespace GHelper
             sliderBattery.KeyUp += SliderBattery_KeyUp;
             sliderBattery.ValueChanged += SliderBattery_ValueChanged;
 
+            sliderBattery.Stops = BatteryControl.GetSupportedLimits(sliderBattery.Step);
+
             sensorTimer = new System.Timers.Timer(AppConfig.Get("sensor_timer", 1000));
             sensorTimer.Elapsed += OnTimedEvent;
             sensorTimer.Enabled = sensorsAlways;

--- a/app/UI/Slider.cs
+++ b/app/UI/Slider.cs
@@ -72,14 +72,19 @@ namespace GHelper.UI
                 _step = value;
             }
         }
+
+        public int[]? Stops { get; set; }
+
         private int _value = 50;
         public int Value
         {
             get => _value;
             set
             {
-
-                value = (int)Math.Round(value / (float)_step) * _step;
+                if (Stops != null && Stops.Length > 0)
+                    value = Stops.MinBy(s => Math.Abs(s - value));
+                else
+                    value = (int)Math.Round(value / (float)_step) * _step;
 
                 if (_value != value)
                 {

--- a/app/UI/Slider.cs
+++ b/app/UI/Slider.cs
@@ -112,16 +112,19 @@ namespace GHelper.UI
 
         protected override void OnKeyDown(KeyEventArgs e)
         {
-
             switch (e.KeyCode)
             {
                 case Keys.Right:
                 case Keys.Up:
-                    Value = Math.Min(Max, Value + Step);
+                    Value = Stops != null
+                        ? (Stops.FirstOrDefault(s => s > Value, Stops[^1]))
+                        : Math.Min(Max, Value + Step);
                     break;
                 case Keys.Left:
                 case Keys.Down:
-                    Value = Math.Max(Min, Value - Step);
+                    Value = Stops != null
+                        ? (Stops.LastOrDefault(s => s < Value, Stops[0]))
+                        : Math.Max(Min, Value - Step);
                     break;
             }
 

--- a/app/UI/Slider.cs
+++ b/app/UI/Slider.cs
@@ -145,12 +145,11 @@ namespace GHelper.UI
 
             if (Stops != null && Stops.Length > 0 && Max > Min)
             {
-                using Pen penNotch = new Pen(Color.Gray, 4f) { StartCap = System.Drawing.Drawing2D.LineCap.Round, EndCap = System.Drawing.Drawing2D.LineCap.Round };
-                float notchHalf = _barSize.Height * 1f;
+                float snapRadius = _barSize.Height * 0.9f;
                 foreach (int stop in Stops)
                 {
                     float x = _barSize.Width / (Max - Min) * (stop - Min) + _barPos.X;
-                    e.Graphics.DrawLine(penNotch, x, _thumbPos.Y - notchHalf, x, _thumbPos.Y + notchHalf);
+                    e.Graphics.FillCircle(brushEmpty, x, _thumbPos.Y, snapRadius);
                 }
             }
 

--- a/app/UI/Slider.cs
+++ b/app/UI/Slider.cs
@@ -142,6 +142,18 @@ namespace GHelper.UI
             Brush brushBorder = new SolidBrush(borderColor);
 
             e.Graphics.SmoothingMode = SmoothingMode.AntiAlias;
+
+            if (Stops != null && Stops.Length > 0 && Max > Min)
+            {
+                using Pen penNotch = new Pen(Color.Gray, 4f) { StartCap = System.Drawing.Drawing2D.LineCap.Round, EndCap = System.Drawing.Drawing2D.LineCap.Round };
+                float notchHalf = _barSize.Height * 1f;
+                foreach (int stop in Stops)
+                {
+                    float x = _barSize.Width / (Max - Min) * (stop - Min) + _barPos.X;
+                    e.Graphics.DrawLine(penNotch, x, _thumbPos.Y - notchHalf, x, _thumbPos.Y + notchHalf);
+                }
+            }
+
             e.Graphics.FillRectangle(brushEmpty,
                 _barPos.X, _barPos.Y, _barSize.Width, _barSize.Height);
             e.Graphics.FillRectangle(brushAccent,


### PR DESCRIPTION
On models with restricted charge limits (e.g. GA403), the slider allowed dragging to values like 90% which the backend immediately remapped to 100%, causing a jarring jump on mouse release.

Extract the clamping logic into ClampLimit() and use it to derive the actual supported stop points for the slider at init time, so snapping happens while dragging rather than after letting go.

See #5383 
