### PR TITLE
Add opt-in OLED dGPU dimming workaround for NVIDIA driver 591+

### DIFF
--- a/app/Display/DisplayNative.cs
+++ b/app/Display/DisplayNative.cs
@@ -470,6 +470,22 @@ namespace GHelper.Display
         [DllImport("gdi32", CharSet = CharSet.Unicode)]
         public static extern IntPtr CreateDC(string driver, string device, string port, IntPtr deviceMode);
 
+        [DllImport("gdi32")]
+        public static extern bool DeleteDC(IntPtr hdc);
+
+        [DllImport("gdi32")]
+        public static extern bool SetDeviceGammaRamp(IntPtr hdc, ref GAMMA_RAMP ramp);
+
+        /// <summary>
+        /// 256 entries per channel x 3 channels (R,G,B), 16-bit each.
+        /// Layout matches what Win32 expects for SetDeviceGammaRamp.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public unsafe struct GAMMA_RAMP
+        {
+            public fixed ushort table[3 * 256];
+        }
+
         [DllImport("gdi32", CharSet = CharSet.Unicode)]
         public static extern bool SetICMProfileW(IntPtr dcHandle, string lpFileName);
 

--- a/app/Display/GdiDimmer.cs
+++ b/app/Display/GdiDimmer.cs
@@ -1,0 +1,163 @@
+using GHelper.Helpers;
+
+namespace GHelper.Display
+{
+    /// <summary>
+    /// Flicker-free dimmer using Win32 SetDeviceGammaRamp on the laptop
+    /// panel only, with a pure-linear ramp matching what AsusSplendid's
+    /// NV CSC matrix produced pre-591.
+    ///
+    /// Workaround for the NVIDIA driver 591.44+ regression where
+    /// NvAPI_GPU_SetColorSpaceConversion (the call AsusSplendid uses for
+    /// flicker-free dimming on the internal panel) returns
+    /// NVAPI_NOT_SUPPORTED (-104) when the dGPU is driving the panel.
+    /// See investigation_results.md in the project root.
+    ///
+    /// Caller is VisualControl.ApplyDimmerForDGpu which remaps slider
+    /// 0..100 -> dimLevel 52..100 in dGPU mode, so the linear ramp always
+    /// stays within the Windows ICM clamp's naturally-accepted window
+    /// (gain >= ~0.50) and the slider responds at every position.
+    ///
+    /// The GDI ramp is applied at the GPU's LUT stage (downstream of DWM
+    /// composition and the hardware cursor), so it dims the cursor, and
+    /// only the laptop panel (other monitors keep their identity ramp).
+    ///
+    /// Known limitations:
+    ///   * Windows ignores SetDeviceGammaRamp on displays in HDR mode.
+    ///   * Linear-gain floor of ~0.52 (see slider remap in VisualControl).
+    ///   * True fullscreen-exclusive D3D games call
+    ///     IDXGIOutput::SetGammaControl(identity) on swapchain creation,
+    ///     wiping our ramp.  Modern Win11 games use Fullscreen
+    ///     Optimisations (DWM-composited borderless) and don't do this.
+    ///     If you ever hit a true-FSE game and the dim disappears,
+    ///     nudge the brightness slider once to re-apply.
+    /// </summary>
+    public static class GdiDimmer
+    {
+        /// <summary>
+        /// AppConfig key (in %APPDATA%\GHelper\config.json) that enables this
+        /// dGPU dimming workaround.  Default off so upstream behaviour is
+        /// unchanged for users on NVIDIA drivers older than 591.44 where
+        /// AsusSplendid's CSC path still works correctly.  Users on the
+        /// broken driver branch (591.44+) enable by setting it to 1.
+        /// </summary>
+        public const string CFG_ENABLED = "oled_dgpu_dimmer_workaround";
+
+        /// <summary>
+        /// True when the user has opted in to the dGPU dimming workaround.
+        /// When false, ApplyDimmerForDGpu is a no-op (and clears any
+        /// previously-active dim).
+        /// </summary>
+        public static bool Enabled => AppConfig.Get(CFG_ENABLED, 0) != 0;
+
+        private static readonly object stateLock = new();
+        private static DisplayNative.GAMMA_RAMP currentRamp;
+        private static string? targetDisplay;
+        private static bool   active;
+
+        public static bool IsActive
+        {
+            get { lock (stateLock) return active; }
+        }
+
+        /// <summary>
+        /// Apply a dim level (0..100 where 100 = no dim, identity ramp).
+        /// Caller is expected to feed a value in [52, 100] (VisualControl
+        /// does this remap for dGPU mode); values below ~52 will be
+        /// silently rejected by the Windows ICM clamp.
+        /// </summary>
+        public static bool Apply(int dimLevel)
+        {
+            int brightness = Math.Clamp(dimLevel, 0, 100);
+            if (brightness >= 100)
+            {
+                Reset();
+                return true;
+            }
+
+            lock (stateLock)
+            {
+                BuildRamp(ref currentRamp, brightness / 100.0);
+
+                targetDisplay = ScreenNative.FindLaptopScreen();
+                if (targetDisplay == null)
+                {
+                    Logger.WriteLine("GdiDimmer: no internal panel resolved, skip");
+                    return false;
+                }
+
+                bool ok = ApplyToDisplay(targetDisplay, ref currentRamp);
+                if (!ok)
+                {
+                    Logger.WriteLine($"GdiDimmer: SetDeviceGammaRamp failed on {targetDisplay} (HDR on?)");
+                    return false;
+                }
+                active = true;
+                Logger.WriteLine($"GdiDimmer: applied {brightness}% on {targetDisplay}");
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Unconditionally restore identity gamma.  Always sends the
+        /// identity ramp to the OS (doesn't short-circuit on the 'active'
+        /// flag) so a stuck dim from a state-mismatch can still be cleared.
+        /// </summary>
+        public static void Reset()
+        {
+            lock (stateLock)
+            {
+                bool wasActive = active;
+                active = false;
+
+                BuildRamp(ref currentRamp, 1.0);
+                var disp = targetDisplay ?? ScreenNative.FindLaptopScreen();
+                if (disp != null)
+                {
+                    ApplyToDisplay(disp, ref currentRamp);
+                    if (wasActive) Logger.WriteLine($"GdiDimmer: reset on {disp}");
+                }
+            }
+        }
+
+        /// <summary>Clear the ramp.  Call from Program.OnExit.</summary>
+        public static void Shutdown()
+        {
+            try { Reset(); } catch { /* best effort */ }
+        }
+
+        private static bool ApplyToDisplay(string device, ref DisplayNative.GAMMA_RAMP r)
+        {
+            var hdc = DisplayNative.CreateDC("DISPLAY", device, null!, IntPtr.Zero);
+            if (hdc == IntPtr.Zero) return false;
+            try
+            {
+                return DisplayNative.SetDeviceGammaRamp(hdc, ref r);
+            }
+            finally
+            {
+                DisplayNative.DeleteDC(hdc);
+            }
+        }
+
+        /// <summary>
+        /// Builds a pure-linear per-channel ramp:
+        ///     out[i] = i * brightness * 257
+        /// (257 = 65535/255, so identity at brightness=1.0).  Same scale
+        /// AsusSplendid's NV CSC matrix used pre-591; whites dim, no
+        /// colour twist.  Cursor and fullscreen-exclusive games are
+        /// reached because the LUT is at the GPU output stage.
+        /// </summary>
+        private static unsafe void BuildRamp(ref DisplayNative.GAMMA_RAMP r, double brightness)
+        {
+            for (int i = 0; i < 256; i++)
+            {
+                double y = i * brightness * 257.0;
+                ushort w = (ushort)Math.Clamp(y, 0, 65535);
+                r.table[      i] = w;
+                r.table[256 + i] = w;
+                r.table[512 + i] = w;
+            }
+        }
+    }
+}

--- a/app/Display/VisualControl.cs
+++ b/app/Display/VisualControl.cs
@@ -1,3 +1,4 @@
+using GHelper.Gpu;
 using GHelper.Helpers;
 using Microsoft.Win32;
 using PawnIO;
@@ -406,16 +407,79 @@ namespace GHelper.Display
             var dimmingLevel = (int)(40 + _brightness * 0.6);
 
             if (AppConfig.IsDUO()) RunSplendid(SplendidCommand.DimmingDuo, 0, dimmingLevel);
-            if (RunSplendid(dimmingCommand, 0, dimmingLevel) == 0) return;
+            if (RunSplendid(dimmingCommand, 0, dimmingLevel) == 0) { ApplyDimmerForDGpu(); return; }
 
             if (_init)
             {
                 _init = false;
                 RunSplendid(SplendidCommand.Init);
                 RunSplendid(SplendidCommand.Init, 4);
-                if (RunSplendid(dimmingCommand, 0, dimmingLevel) == 0) return;
+                if (RunSplendid(dimmingCommand, 0, dimmingLevel) == 0) { ApplyDimmerForDGpu(); return; }
             }
 
+            ApplyDimmerForDGpu();
+        }
+
+        /// <summary>
+        /// In Ultimate (dGPU) mode, apply a per-display GDI gamma ramp on
+        /// the laptop panel with a slider remap of 0..100 -> dimLevel
+        /// 52..100 (slider 0 -> 52, slider 100 -> 100).
+        ///
+        /// Opt-in via the AppConfig key <see cref="GdiDimmer.CFG_ENABLED"/>
+        /// (defaults to off).  Users on the broken NVIDIA driver branch
+        /// (591.44+) where AsusSplendid's CSC silently fails should
+        /// enable this; users on older drivers where Splendid's CSC still
+        /// works should leave it off, because applying both Splendid's
+        /// scale and this GDI ramp compounds (effective gain = g*g) and
+        /// over-dims the panel.
+        ///
+        /// The 52 floor is chosen empirically: Windows' ICM clamp silently
+        /// rejects linear gamma ramps whose values deviate more than
+        /// ~32768 from identity, i.e. a linear gain floor of ~0.50.  The
+        /// documented GdiICMGammaRange=256 registry tweak that should
+        /// disable this clamp does NOT take effect on Win11 25H2
+        /// (verified by SetDeviceGammaRamp round-trip test), so we stay
+        /// above ~0.50.  This costs roughly the bottom 20% of Splendid's
+        /// brightness range (slider 0 = scale 0.52 vs Splendid's 0.40;
+        /// gap 0.12 / span 0.60 = 20%) in exchange for the slider
+        /// responding at every position.
+        ///
+        /// The GDI ramp is applied at the GPU's LUT stage (downstream of
+        /// DWM composition and the hardware cursor), so it dims the
+        /// cursor and fullscreen-exclusive games, and only the laptop
+        /// panel (other monitors keep identity).
+        ///
+        /// In iGPU / Standard / Eco mode this method only clears any
+        /// previously-active dim - AsusSplendid's AMD/Intel paths handle
+        /// dimming natively there.  The Splendid dimmingLevel sent above
+        /// (40..100) is unchanged regardless of whether the workaround
+        /// is enabled.
+        /// </summary>
+        private static void ApplyDimmerForDGpu()
+        {
+            try
+            {
+                // Opt-in gate.  When disabled, ensure no leftover dim is
+                // active (covers the case where the user toggled the
+                // workaround off mid-session).
+                if (!GdiDimmer.Enabled)
+                {
+                    if (GdiDimmer.IsActive) GdiDimmer.Reset();
+                    return;
+                }
+                if (GPUModeControl.gpuMode != AsusACPI.GPUModeUltimate ||
+                    !AppConfig.IsOLED() || _brightness >= 100)
+                {
+                    if (GdiDimmer.IsActive) GdiDimmer.Reset();
+                    return;
+                }
+                // slider 0..100 -> dimLevel 52..100 (linear, ICM-clamp-safe)
+                GdiDimmer.Apply((int)Math.Round(52 + _brightness * 0.48));
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteLine("Dimmer error: " + ex.Message);
+            }
         }
 
         public static void InitBrightness()

--- a/app/Display/VisualControl.cs
+++ b/app/Display/VisualControl.cs
@@ -478,7 +478,7 @@ namespace GHelper.Display
             }
             catch (Exception ex)
             {
-                Logger.WriteLine("Dimmer error: " + ex.Message);
+                Logger.WriteLine("Dimmer error: " + ex.ToString());
             }
         }
 

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -461,6 +461,7 @@ namespace GHelper
                 trayIcon.Dispose();
             }
 
+            GdiDimmer.Shutdown();
             PeripheralsProvider.UnregisterForDeviceEvents();
             clamshellControl.UnregisterDisplayEvents();
             NativeMethods.UnregisterPowerSettingNotification(unRegPowerNotify);


### PR DESCRIPTION
## Summary

On ROG / ProArt laptops with an OLED panel in dGPU / Ultimate mode, NVIDIA driver
591.44+ gates the private `NvAPI_GPU_SetColorSpaceConversion` call that
`AsusSplendid.exe` relies on (it returns `NVAPI_NOT_SUPPORTED` / -104 for the
internal eDP panel), so the OLED brightness slider in g-helper, Armoury Crate,
and ASCI itself silently does nothing on the affected driver branch.

This PR adds a small `GdiDimmer` that writes a linear gamma ramp via Win32
`SetDeviceGammaRamp` on the laptop panel only, when the system is in Ultimate
mode and the panel is OLED. Visible dim returns; the LUT sits at the GPU output
stage, so cursor and FSO / borderless games dim too.

**Opt-in** via AppConfig key `"oled_dgpu_dimmer_workaround": 1` in
`%APPDATA%\GHelper\config.json` (default `0`). Off-by-default protects users
on pre-591 drivers where Splendid's CSC still works — stacking the two paths
would over-dim multiplicatively.

## What changed

- **New** `app/Display/GdiDimmer.cs` (~145 lines) — the dimmer itself.
- `app/Display/DisplayNative.cs` — three additive P/Invoke declarations.
- `app/Display/VisualControl.cs` — three minimal touches in `BrightnessTimerTimer_Elapsed`
  (two existing `return;` lines wrapped, one trailing call appended) + the new
  `ApplyDimmerForDGpu` helper. **No existing control flow or logic modified.**
- `app/Program.cs` — one line in `OnExit` to restore identity gamma on quit
  (see "Note for reviewers" below).

iGPU mode is completely untouched — `AsusSplendid`'s AMD ADL/ADLX path still
handles dimming natively there.

## Known limitations

- Windows ICM clamp rejects ramps with gain < ~0.50, so the slider 0..100 is
  remapped to dim level 52..100 internally (bottom ~20% of Splendid's range
  cannot be reached, but every slider position stays responsive).
- Windows ignores `SetDeviceGammaRamp` in HDR mode (Splendid was the same — HDR
  already disables Splendid dimming today).
- True FSE D3D games wipe the ramp on swapchain init (rare on Win11); nudging
  the slider once after the game starts re-applies it.

## Note for reviewers: `Program.OnExit` is unwired upstream

While integrating the `GdiDimmer.Shutdown()` cleanup, I discovered that
`Program.OnExit` (where I put the call) is **not wired to any event** in
upstream — no `Application.ApplicationExit += OnExit`, no
`AppDomain.CurrentDomain.ProcessExit += OnExit`. The giveaway is that
`OnExit` calls `Application.Exit()` from inside itself, which would be
infinite recursion if it were an event handler.

In practice this means `OnExit`'s entire body — tray icon dispose,
power-notification unregister, suspend/resume unregister, and now my
`GdiDimmer.Shutdown()` — never runs on app exit. The OS reclaims most of
that on process teardown, so upstream hasn't noticed, but the dimmer's
gamma ramp is one of the few things that *outlives the process* (it's held
in the GPU's LUT until something else writes the LUT), so the side-effect
is visible: the panel stays dimmed after g-helper quits until the user
logs out, the display sleeps, or a game resets the LUT.

I left the cleanup call inside `OnExit` rather than fixing the wiring in
this PR, because wiring up `OnExit` would change behaviour for all the
other cleanup it does (potentially in subtle ways across the rest of the
codebase) and that feels out of scope.

## Test plan

- [x] dGPU/Ultimate mode + OLED + driver 596.49 — slider responsive from 0..100, no flicker.
- [x] iGPU mode — behaviour byte-identical to upstream (new code path is a no-op).
- [x] Config key absent or `0` — behaviour byte-identical to upstream.
- [x] HDR on — gracefully fails, logs once, identity ramp preserved.
- [x] Hardware directly verified: ROG Zephyrus G16 GA605WV, RTX 4060, driver 596.49.
- [ ] Other RTX 30/40/50-series ROG/ProArt OLED laptops on driver 591.44+ should
      also benefit (the regression is driver-wide, not model-specific), but only
      the configuration above was directly verified by me.

A longer technical write-up of the investigation (12 alternative paths ruled
out, why we landed on `SetDeviceGammaRamp`) is available in my fork's
`INVESTIGATION.md` if helpful for review.
