### PR TITLE
Add MCP server support for AI assistant control

### DIFF
--- a/app/Mcp/McpProtocol.cs
+++ b/app/Mcp/McpProtocol.cs
@@ -1,0 +1,176 @@
+using System.Reflection;
+using System.Text.Json.Nodes;
+
+namespace GHelper.Mcp
+{
+    /// <summary>
+    /// JSON-RPC 2.0 message construction and MCP method dispatch
+    /// (initialize / tools/list / tools/call / ping).
+    /// </summary>
+    internal static class McpProtocol
+    {
+        // JSON-RPC error codes.
+        private const int ParseErrorCode = -32700;
+        private const int InvalidRequestCode = -32600;
+        private const int MethodNotFoundCode = -32601;
+        private const int InvalidParamsCode = -32602;
+        private const int InternalErrorCode = -32603;
+
+        /// <summary>
+        /// Handles a single JSON-RPC request and returns the response object to send back.
+        /// When the method is "initialize", <paramref name="newSessionId"/> is set so the
+        /// transport can emit the Mcp-Session-Id header.
+        /// </summary>
+        public static JsonObject Dispatch(string method, JsonObject? parameters, JsonNode? id, out string? newSessionId)
+        {
+            newSessionId = null;
+
+            try
+            {
+                switch (method)
+                {
+                    case "initialize":
+                        newSessionId = McpServer.NewSessionId();
+                        return Result(id, Initialize(parameters));
+
+                    case "notifications/initialized":
+                        // Should arrive as a notification (no id); answered here defensively.
+                        return Result(id, new JsonObject());
+
+                    case "ping":
+                        return Result(id, new JsonObject());
+
+                    case "tools/list":
+                        return Result(id, ToolsList());
+
+                    case "tools/call":
+                        return Result(id, ToolsCall(parameters));
+
+                    default:
+                        return Error(id, MethodNotFoundCode, $"Method not found: {method}");
+                }
+            }
+            catch (McpToolException ex)
+            {
+                return Error(id, InvalidParamsCode, ex.Message);
+            }
+            catch (Exception ex)
+            {
+                return Error(id, InternalErrorCode, ex.Message);
+            }
+        }
+
+        private static JsonObject Initialize(JsonObject? parameters)
+        {
+            // Echo back the client's protocol version when we support it, else our preferred.
+            string requested = parameters?["protocolVersion"]?.GetValue<string>() ?? McpServer.PreferredProtocolVersion;
+            string version = McpServer.IsProtocolSupported(requested) ? requested : McpServer.PreferredProtocolVersion;
+
+            string appVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "0";
+
+            return new JsonObject
+            {
+                ["protocolVersion"] = version,
+                ["capabilities"] = new JsonObject
+                {
+                    ["tools"] = new JsonObject { ["listChanged"] = false }
+                },
+                ["serverInfo"] = new JsonObject
+                {
+                    ["name"] = "G-Helper",
+                    ["version"] = appVersion
+                },
+                ["instructions"] = "Controls and reads telemetry from an Asus laptop running G-Helper. " +
+                    "Use get_status / get_sensors to read state, and the set_* tools to change performance mode, " +
+                    "GPU mode, battery charge limit, keyboard backlight and screen refresh rate."
+            };
+        }
+
+        private static JsonObject ToolsList()
+        {
+            var tools = new JsonArray();
+            foreach (var tool in McpTools.All)
+            {
+                tools.Add(new JsonObject
+                {
+                    ["name"] = tool.Name,
+                    ["description"] = tool.Description,
+                    ["inputSchema"] = tool.InputSchema.DeepClone()
+                });
+            }
+            return new JsonObject { ["tools"] = tools };
+        }
+
+        private static JsonObject ToolsCall(JsonObject? parameters)
+        {
+            string? name = parameters?["name"]?.GetValue<string>();
+            if (string.IsNullOrEmpty(name))
+                throw new McpToolException("Missing tool name");
+
+            var tool = McpTools.Find(name);
+            if (tool is null)
+                throw new McpToolException($"Unknown tool: {name}");
+
+            JsonObject args = parameters?["arguments"] as JsonObject ?? new JsonObject();
+
+            try
+            {
+                string text = McpTools.Invoke(tool, args);
+                return ToolText(text, isError: false);
+            }
+            catch (McpToolException ex)
+            {
+                // Tool-level failures are reported via isError content, not a protocol error,
+                // so the model can read and react to the message.
+                return ToolText(ex.Message, isError: true);
+            }
+            catch (Exception ex)
+            {
+                return ToolText($"Error: {ex.Message}", isError: true);
+            }
+        }
+
+        private static JsonObject ToolText(string text, bool isError)
+        {
+            return new JsonObject
+            {
+                ["content"] = new JsonArray
+                {
+                    new JsonObject { ["type"] = "text", ["text"] = text }
+                },
+                ["isError"] = isError
+            };
+        }
+
+        #region JSON-RPC envelope builders
+
+        private static JsonObject Result(JsonNode? id, JsonObject result) => new()
+        {
+            ["jsonrpc"] = "2.0",
+            ["id"] = id?.DeepClone(),
+            ["result"] = result
+        };
+
+        private static JsonObject Error(JsonNode? id, int code, string message) => new()
+        {
+            ["jsonrpc"] = "2.0",
+            ["id"] = id?.DeepClone(),
+            ["error"] = new JsonObject { ["code"] = code, ["message"] = message }
+        };
+
+        public static JsonObject ParseError() => new()
+        {
+            ["jsonrpc"] = "2.0",
+            ["id"] = null,
+            ["error"] = new JsonObject { ["code"] = ParseErrorCode, ["message"] = "Parse error" }
+        };
+
+        #endregion
+    }
+
+    /// <summary>Thrown by tool handlers for user-facing failures (bad args, unsupported hardware).</summary>
+    internal class McpToolException : Exception
+    {
+        public McpToolException(string message) : base(message) { }
+    }
+}

--- a/app/Mcp/McpServer.cs
+++ b/app/Mcp/McpServer.cs
@@ -1,0 +1,355 @@
+using GHelper.Helpers;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace GHelper.Mcp
+{
+    /// <summary>
+    /// A minimal, self-contained Model Context Protocol (MCP) server.
+    ///
+    /// It exposes G-Helper's telemetry and controls as MCP "tools" so that AI assistants
+    /// (Claude Desktop / Claude Code / any MCP client) can read sensors and change laptop
+    /// settings. The implementation speaks the MCP "Streamable HTTP" transport directly on
+    /// top of <see cref="HttpListener"/> so it adds no extra NuGet dependencies.
+    ///
+    /// Security model (see <see cref="HandleRequest"/>):
+    ///  - Disabled by default; opt-in via the "mcp_enabled" config flag / tray menu.
+    ///  - Bound to 127.0.0.1 only (never all interfaces).
+    ///  - Requires a bearer token (auto-generated, stored in config) on every request.
+    ///  - Validates the Origin header to block DNS-rebinding attacks from browsers.
+    /// </summary>
+    public static class McpServer
+    {
+        public const int DefaultPort = 8787;
+
+        // Protocol versions we understand. We answer "initialize" with the client's
+        // requested version when we support it, otherwise with our preferred one.
+        public const string PreferredProtocolVersion = "2025-06-18";
+        private static readonly HashSet<string> SupportedProtocolVersions = new()
+        {
+            "2025-06-18", "2025-03-26", "2024-11-05"
+        };
+
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+        };
+
+        private static readonly object _lock = new();
+        private static HttpListener? _listener;
+        private static CancellationTokenSource? _cts;
+
+        // Active session ids handed out at initialize time. Kept so we can validate /
+        // expire them, but we stay lenient about clients that omit the header.
+        private static readonly HashSet<string> _sessions = new();
+
+        public static bool IsRunning
+        {
+            get { lock (_lock) return _listener is not null && _listener.IsListening; }
+        }
+
+        #region Config accessors
+
+        public static bool Enabled
+        {
+            get => AppConfig.Is("mcp_enabled");
+            set => AppConfig.Set("mcp_enabled", value ? 1 : 0);
+        }
+
+        public static int Port
+        {
+            get
+            {
+                int port = AppConfig.Get("mcp_port", DefaultPort);
+                return (port > 0 && port <= 65535) ? port : DefaultPort;
+            }
+        }
+
+        /// <summary>Bearer token required on every request. Generated once and persisted.</summary>
+        public static string Token
+        {
+            get
+            {
+                string? token = AppConfig.GetString("mcp_token");
+                if (string.IsNullOrEmpty(token))
+                {
+                    token = Convert.ToHexString(RandomNumberGenerator.GetBytes(24)).ToLowerInvariant();
+                    AppConfig.Set("mcp_token", token);
+                }
+                return token;
+            }
+        }
+
+        public static string Url => $"http://127.0.0.1:{Port}/mcp";
+
+        #endregion
+
+        /// <summary>Starts or stops the server to match the current "mcp_enabled" flag.</summary>
+        public static void ApplyState()
+        {
+            if (Enabled) Start();
+            else Stop();
+        }
+
+        public static void Start()
+        {
+            lock (_lock)
+            {
+                if (_listener is not null && _listener.IsListening) return;
+
+                try
+                {
+                    var listener = new HttpListener();
+                    // Bind to loopback only. Match both "/mcp" and "/mcp/..." by listening at root.
+                    listener.Prefixes.Add($"http://127.0.0.1:{Port}/");
+                    listener.Start();
+
+                    _listener = listener;
+                    _cts = new CancellationTokenSource();
+
+                    // Touch the token so it is generated/persisted before first use.
+                    _ = Token;
+
+                    Task.Run(() => AcceptLoop(listener, _cts.Token));
+                    Logger.WriteLine($"MCP server listening on {Url}");
+                }
+                catch (HttpListenerException ex)
+                {
+                    // Access-denied (5) typically means the URL ACL is missing and G-Helper
+                    // is not elevated. Hardware control already needs admin, so this is rare.
+                    _listener = null;
+                    Logger.WriteLine($"MCP server failed to start on port {Port}: {ex.Message} " +
+                        "(run G-Helper as administrator, or reserve the URL with: " +
+                        $"netsh http add urlacl url=http://127.0.0.1:{Port}/ user=Everyone)");
+                }
+                catch (Exception ex)
+                {
+                    _listener = null;
+                    Logger.WriteLine($"MCP server failed to start: {ex.Message}");
+                }
+            }
+        }
+
+        public static void Stop()
+        {
+            lock (_lock)
+            {
+                if (_listener is null) return;
+                try
+                {
+                    _cts?.Cancel();
+                    _listener.Stop();
+                    _listener.Close();
+                    Logger.WriteLine("MCP server stopped");
+                }
+                catch (Exception ex)
+                {
+                    Logger.WriteLine($"MCP server stop error: {ex.Message}");
+                }
+                finally
+                {
+                    _listener = null;
+                    _cts = null;
+                    _sessions.Clear();
+                }
+            }
+        }
+
+        private static async Task AcceptLoop(HttpListener listener, CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                HttpListenerContext context;
+                try
+                {
+                    context = await listener.GetContextAsync();
+                }
+                catch (Exception)
+                {
+                    // Listener stopped/disposed - exit the loop quietly.
+                    break;
+                }
+
+                // Handle each request independently; never let one failure kill the loop.
+                _ = Task.Run(() =>
+                {
+                    try { HandleRequest(context); }
+                    catch (Exception ex) { Logger.WriteLine($"MCP request error: {ex.Message}"); }
+                });
+            }
+        }
+
+        private static void HandleRequest(HttpListenerContext context)
+        {
+            var request = context.Request;
+            var response = context.Response;
+
+            try
+            {
+                // --- DNS-rebinding protection: reject cross-origin browser requests. ---
+                string? origin = request.Headers["Origin"];
+                if (!string.IsNullOrEmpty(origin) && !IsLocalOrigin(origin))
+                {
+                    WriteStatus(response, 403, "Forbidden origin");
+                    return;
+                }
+
+                // --- Authentication: bearer token on every request. ---
+                if (!IsAuthorized(request))
+                {
+                    response.AddHeader("WWW-Authenticate", "Bearer");
+                    WriteStatus(response, 401, "Unauthorized");
+                    return;
+                }
+
+                // --- Routing: only the MCP endpoint is served. ---
+                string path = request.Url?.AbsolutePath.TrimEnd('/') ?? "";
+                if (path != "/mcp" && path != "")
+                {
+                    WriteStatus(response, 404, "Not found");
+                    return;
+                }
+
+                switch (request.HttpMethod)
+                {
+                    case "POST":
+                        HandlePost(request, response);
+                        break;
+
+                    case "DELETE":
+                        // Client asked to terminate its session.
+                        string? sid = request.Headers["Mcp-Session-Id"];
+                        if (!string.IsNullOrEmpty(sid)) lock (_lock) _sessions.Remove(sid);
+                        WriteStatus(response, 200, "OK");
+                        break;
+
+                    case "GET":
+                        // We do not offer a server-initiated SSE stream.
+                        WriteStatus(response, 405, "Method Not Allowed");
+                        break;
+
+                    default:
+                        WriteStatus(response, 405, "Method Not Allowed");
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteLine($"MCP handler error: {ex.Message}");
+                try { WriteStatus(response, 500, "Internal error"); } catch { }
+            }
+            finally
+            {
+                try { response.OutputStream.Close(); } catch { }
+            }
+        }
+
+        private static void HandlePost(HttpListenerRequest request, HttpListenerResponse response)
+        {
+            string body;
+            using (var reader = new StreamReader(request.InputStream, request.ContentEncoding ?? Encoding.UTF8))
+                body = reader.ReadToEnd();
+
+            JsonNode? message;
+            try
+            {
+                message = JsonNode.Parse(body);
+            }
+            catch (Exception)
+            {
+                WriteJson(response, 200, McpProtocol.ParseError());
+                return;
+            }
+
+            if (message is not JsonObject obj)
+            {
+                WriteJson(response, 200, McpProtocol.ParseError());
+                return;
+            }
+
+            // A JSON-RPC notification or response carries no "id" that needs answering
+            // (notifications have no id; method-less messages are responses). Ack with 202.
+            bool hasId = obj.ContainsKey("id") && obj["id"] is not null;
+            bool hasMethod = obj.ContainsKey("method");
+            if (!hasMethod || !hasId)
+            {
+                WriteStatus(response, 202, "Accepted");
+                return;
+            }
+
+            JsonNode? id = obj["id"]?.DeepClone();
+            string method = obj["method"]!.GetValue<string>();
+            JsonObject? parameters = obj["params"] as JsonObject;
+
+            JsonObject result = McpProtocol.Dispatch(method, parameters, id, out string? newSessionId);
+
+            if (newSessionId is not null)
+            {
+                lock (_lock) _sessions.Add(newSessionId);
+                response.AddHeader("Mcp-Session-Id", newSessionId);
+            }
+
+            WriteJson(response, 200, result);
+        }
+
+        #region Security helpers
+
+        private static bool IsAuthorized(HttpListenerRequest request)
+        {
+            string? auth = request.Headers["Authorization"];
+            if (string.IsNullOrEmpty(auth) || !auth.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+                return false;
+
+            string provided = auth.Substring("Bearer ".Length).Trim();
+            return FixedTimeEquals(provided, Token);
+        }
+
+        private static bool FixedTimeEquals(string a, string b)
+        {
+            byte[] ba = Encoding.UTF8.GetBytes(a);
+            byte[] bb = Encoding.UTF8.GetBytes(b);
+            return CryptographicOperations.FixedTimeEquals(ba, bb);
+        }
+
+        private static bool IsLocalOrigin(string origin)
+        {
+            if (!Uri.TryCreate(origin, UriKind.Absolute, out var uri)) return false;
+            string host = uri.Host;
+            return host.Equals("127.0.0.1", StringComparison.OrdinalIgnoreCase)
+                || host.Equals("localhost", StringComparison.OrdinalIgnoreCase)
+                || host.Equals("::1", StringComparison.OrdinalIgnoreCase);
+        }
+
+        #endregion
+
+        #region Response writers
+
+        public static string NewSessionId() =>
+            Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant();
+
+        private static void WriteJson(HttpListenerResponse response, int status, JsonObject payload)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(payload.ToJsonString(JsonOptions));
+            response.StatusCode = status;
+            response.ContentType = "application/json";
+            response.ContentLength64 = bytes.Length;
+            response.OutputStream.Write(bytes, 0, bytes.Length);
+        }
+
+        private static void WriteStatus(HttpListenerResponse response, int status, string message)
+        {
+            byte[] bytes = Encoding.UTF8.GetBytes(message);
+            response.StatusCode = status;
+            response.ContentType = "text/plain";
+            response.ContentLength64 = bytes.Length;
+            response.OutputStream.Write(bytes, 0, bytes.Length);
+        }
+
+        #endregion
+
+        public static bool IsProtocolSupported(string version) => SupportedProtocolVersions.Contains(version);
+    }
+}

--- a/app/Mcp/McpTools.cs
+++ b/app/Mcp/McpTools.cs
@@ -1,0 +1,349 @@
+using GHelper.Battery;
+using GHelper.Display;
+using GHelper.Helpers;
+using GHelper.Input;
+using GHelper.Mode;
+using GHelper.USB;
+using System.Text.Json.Nodes;
+
+namespace GHelper.Mcp
+{
+    internal record McpTool(string Name, string Description, JsonObject InputSchema, Func<JsonObject, string> Handler);
+
+    /// <summary>
+    /// The set of MCP tools exposed to clients. Each tool wraps an existing G-Helper control
+    /// or telemetry source. Handlers are marshaled onto the UI thread in <see cref="Invoke"/>
+    /// because most controllers touch WinForms state and the ACPI device.
+    /// </summary>
+    internal static class McpTools
+    {
+        private static readonly JsonObject NoArgs = new()
+        {
+            ["type"] = "object",
+            ["properties"] = new JsonObject(),
+            ["additionalProperties"] = false
+        };
+
+        public static readonly McpTool[] All =
+        {
+            new("get_status",
+                "Get a full snapshot of the laptop state: model, performance mode, GPU mode, " +
+                "power source, battery charge percentage and limit, screen refresh rate, and keyboard backlight level.",
+                NoArgs.DeepClone().AsObject(),
+                GetStatus),
+
+            new("get_sensors",
+                "Read live hardware sensors: CPU and GPU temperature (°C), CPU/GPU/Mid fan speed (RPM), " +
+                "and CPU/GPU power draw (W). Values may be null when unsupported by the model.",
+                NoArgs.DeepClone().AsObject(),
+                GetSensors),
+
+            new("list_performance_modes",
+                "List the available performance modes (built-in Silent/Balanced/Turbo plus any custom modes) and the current one.",
+                NoArgs.DeepClone().AsObject(),
+                ListPerformanceModes),
+
+            new("set_performance_mode",
+                "Set the laptop performance mode. Controls fan profile, power limits and the Windows power plan.",
+                new JsonObject
+                {
+                    ["type"] = "object",
+                    ["properties"] = new JsonObject
+                    {
+                        ["mode"] = new JsonObject
+                        {
+                            ["type"] = "string",
+                            ["enum"] = new JsonArray("silent", "balanced", "turbo"),
+                            ["description"] = "Performance mode to activate."
+                        }
+                    },
+                    ["required"] = new JsonArray("mode"),
+                    ["additionalProperties"] = false
+                },
+                SetPerformanceMode),
+
+            new("set_gpu_mode",
+                "Set the discrete GPU mode. 'eco' disables the dGPU (best battery life); 'standard' enables Optimus/hybrid. " +
+                "Ultimate mode is intentionally not supported here because it forces a reboot.",
+                new JsonObject
+                {
+                    ["type"] = "object",
+                    ["properties"] = new JsonObject
+                    {
+                        ["mode"] = new JsonObject
+                        {
+                            ["type"] = "string",
+                            ["enum"] = new JsonArray("eco", "standard"),
+                            ["description"] = "GPU mode to activate."
+                        }
+                    },
+                    ["required"] = new JsonArray("mode"),
+                    ["additionalProperties"] = false
+                },
+                SetGpuMode),
+
+            new("set_battery_limit",
+                "Set the battery charge limit as a percentage (40-100). Lower limits preserve long-term battery health.",
+                new JsonObject
+                {
+                    ["type"] = "object",
+                    ["properties"] = new JsonObject
+                    {
+                        ["percent"] = new JsonObject
+                        {
+                            ["type"] = "integer",
+                            ["minimum"] = 40,
+                            ["maximum"] = 100,
+                            ["description"] = "Maximum charge level (40-100). Some models only support 60/80/100."
+                        }
+                    },
+                    ["required"] = new JsonArray("percent"),
+                    ["additionalProperties"] = false
+                },
+                SetBatteryLimit),
+
+            new("set_keyboard_backlight",
+                "Set the keyboard backlight brightness level: 0 = off, 1 = low, 2 = medium, 3 = high.",
+                new JsonObject
+                {
+                    ["type"] = "object",
+                    ["properties"] = new JsonObject
+                    {
+                        ["level"] = new JsonObject
+                        {
+                            ["type"] = "integer",
+                            ["minimum"] = 0,
+                            ["maximum"] = 3,
+                            ["description"] = "Backlight level 0-3."
+                        }
+                    },
+                    ["required"] = new JsonArray("level"),
+                    ["additionalProperties"] = false
+                },
+                SetKeyboardBacklight),
+
+            new("set_refresh_rate",
+                "Set the laptop display refresh rate in Hz. Use 0 for the lowest supported rate and 1000 for the maximum.",
+                new JsonObject
+                {
+                    ["type"] = "object",
+                    ["properties"] = new JsonObject
+                    {
+                        ["rate"] = new JsonObject
+                        {
+                            ["type"] = "integer",
+                            ["minimum"] = 0,
+                            ["description"] = "Refresh rate in Hz (0 = minimum, 1000 = maximum)."
+                        }
+                    },
+                    ["required"] = new JsonArray("rate"),
+                    ["additionalProperties"] = false
+                },
+                SetRefreshRate),
+        };
+
+        public static McpTool? Find(string name) => All.FirstOrDefault(t => t.Name == name);
+
+        /// <summary>Runs a tool handler on the UI thread so it can safely touch WinForms + ACPI.</summary>
+        public static string Invoke(McpTool tool, JsonObject args)
+        {
+            var form = Program.settingsForm;
+            if (form is not null && !form.IsDisposed && form.IsHandleCreated)
+                return (string)form.Invoke(new Func<string>(() => tool.Handler(args)));
+
+            return tool.Handler(args);
+        }
+
+        #region Telemetry tools
+
+        private static string GetStatus(JsonObject args)
+        {
+            int mode = Modes.GetCurrent();
+            int gpuMode = AppConfig.Get("gpu_mode", Gpu.GPUModeControl.gpuMode);
+            bool acOnline = SystemInformation.PowerStatus.PowerLineStatus == PowerLineStatus.Online;
+
+            var status = new JsonObject
+            {
+                ["model"] = AppConfig.GetModelShort(),
+                ["performance_mode"] = new JsonObject
+                {
+                    ["id"] = mode,
+                    ["name"] = Modes.GetName(mode)
+                },
+                ["gpu_mode"] = new JsonObject
+                {
+                    ["id"] = gpuMode,
+                    ["name"] = GpuModeName(gpuMode)
+                },
+                ["power_source"] = Program.ReadPowerSource().ToString(),
+                ["ac_connected"] = acOnline,
+                ["battery"] = new JsonObject
+                {
+                    ["percent"] = Math.Round(HardwareControl.GetBatteryChargePercentage()),
+                    ["charge_limit"] = AppConfig.Get("charge_limit", 100),
+                    ["charge_full"] = BatteryControl.chargeFull
+                },
+                ["display"] = new JsonObject
+                {
+                    ["refresh_rate"] = AppConfig.Get("frequency"),
+                    ["max_refresh_rate"] = AppConfig.Get("max_frequency")
+                },
+                ["keyboard_backlight"] = InputDispatcher.GetBacklight()
+            };
+
+            return status.ToJsonString();
+        }
+
+        private static string GetSensors(JsonObject args)
+        {
+            HardwareControl.ReadSensors();
+
+            var sensors = new JsonObject
+            {
+                ["cpu_temp_c"] = ToTemp(HardwareControl.cpuTemp),
+                ["gpu_temp_c"] = ToTemp(HardwareControl.gpuTemp),
+                ["cpu_fan_rpm"] = FanRpm(AsusFan.CPU),
+                ["gpu_fan_rpm"] = FanRpm(AsusFan.GPU),
+                ["mid_fan_rpm"] = FanRpm(AsusFan.Mid),
+                ["cpu_power_w"] = ToPower(HardwareControl.cpuPower),
+                ["gpu_power_w"] = ToPower(HardwareControl.gpuPower)
+            };
+
+            return sensors.ToJsonString();
+        }
+
+        private static string ListPerformanceModes(JsonObject args)
+        {
+            var modes = new JsonArray();
+            foreach (var kvp in Modes.GetDictonary())
+                modes.Add(new JsonObject { ["id"] = kvp.Key, ["name"] = kvp.Value });
+
+            return new JsonObject
+            {
+                ["modes"] = modes,
+                ["current"] = Modes.GetCurrent()
+            }.ToJsonString();
+        }
+
+        #endregion
+
+        #region Control tools
+
+        private static string SetPerformanceMode(JsonObject args)
+        {
+            string mode = RequireString(args, "mode").ToLowerInvariant();
+            int modeId = mode switch
+            {
+                "silent" => (int)AsusMode.Silent,
+                "balanced" => (int)AsusMode.Balanced,
+                "turbo" => (int)AsusMode.Turbo,
+                _ => throw new McpToolException($"Unknown performance mode: {mode}")
+            };
+
+            Program.modeControl.SetPerformanceMode(modeId, notify: true);
+            return $"Performance mode set to {Modes.GetName(modeId)}.";
+        }
+
+        private static string SetGpuMode(JsonObject args)
+        {
+            string mode = RequireString(args, "mode").ToLowerInvariant();
+            int target = mode switch
+            {
+                "eco" => AsusACPI.GPUModeEco,
+                "standard" => AsusACPI.GPUModeStandard,
+                _ => throw new McpToolException($"Unsupported GPU mode: {mode}. Use 'eco' or 'standard'.")
+            };
+
+            int current = AppConfig.Get("gpu_mode", Gpu.GPUModeControl.gpuMode);
+            if (current == AsusACPI.GPUModeUltimate)
+                throw new McpToolException("GPU is in Ultimate mode; switching out of it requires a reboot and must be done from the G-Helper UI.");
+
+            Program.gpuControl.SetGPUMode(target);
+            return $"GPU mode set to {GpuModeName(target)}.";
+        }
+
+        private static string SetBatteryLimit(JsonObject args)
+        {
+            int percent = RequireInt(args, "percent");
+            if (percent < 40 || percent > 100)
+                throw new McpToolException("Battery limit must be between 40 and 100.");
+
+            BatteryControl.SetBatteryChargeLimit(percent);
+            return $"Battery charge limit set to {AppConfig.Get("charge_limit", percent)}%.";
+        }
+
+        private static string SetKeyboardBacklight(JsonObject args)
+        {
+            int level = RequireInt(args, "level");
+            if (level < 0 || level > 3)
+                throw new McpToolException("Backlight level must be between 0 and 3.");
+
+            // Persist for both power states and apply immediately.
+            AppConfig.Set("keyboard_brightness", level);
+            AppConfig.Set("keyboard_brightness_ac", level);
+            Aura.ApplyBrightness(level, "MCP");
+
+            string[] names = { "off", "low", "medium", "high" };
+            return $"Keyboard backlight set to {names[level]}.";
+        }
+
+        private static string SetRefreshRate(JsonObject args)
+        {
+            int rate = RequireInt(args, "rate");
+
+            int frequency;
+            if (rate <= 0) frequency = ScreenControl.MIN_RATE;
+            else if (rate >= ScreenControl.MAX_REFRESH) frequency = ScreenControl.MAX_REFRESH;
+            else frequency = rate;
+
+            ScreenControl.SetScreen(frequency: frequency);
+            return $"Display refresh rate set to {AppConfig.Get("frequency")} Hz.";
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static string GpuModeName(int mode) => mode switch
+        {
+            AsusACPI.GPUModeEco => "Eco",
+            AsusACPI.GPUModeStandard => "Standard",
+            AsusACPI.GPUModeUltimate => "Ultimate",
+            _ => "Unknown"
+        };
+
+        private static JsonNode? ToTemp(float? value) =>
+            (value is null || value <= 0) ? null : JsonValue.Create(Math.Round(value.Value, 1));
+
+        private static JsonNode? ToPower(float? value) =>
+            (value is null || value <= 0) ? null : JsonValue.Create(Math.Round(value.Value, 1));
+
+        private static JsonNode? FanRpm(AsusFan fan)
+        {
+            int raw = Program.acpi?.GetFan(fan) ?? -1;
+            return raw < 0 ? null : JsonValue.Create(raw * 100);
+        }
+
+        private static string RequireString(JsonObject args, string key)
+        {
+            JsonNode? node = args[key];
+            if (node is null) throw new McpToolException($"Missing required argument: {key}");
+            return node.GetValue<string>();
+        }
+
+        private static int RequireInt(JsonObject args, string key)
+        {
+            JsonNode? node = args[key];
+            if (node is null) throw new McpToolException($"Missing required argument: {key}");
+
+            try { return node.GetValue<int>(); }
+            catch
+            {
+                if (int.TryParse(node.ToString(), out int value)) return value;
+                throw new McpToolException($"Argument '{key}' must be an integer.");
+            }
+        }
+
+        #endregion
+    }
+}

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -4,6 +4,7 @@ using GHelper.Display;
 using GHelper.Gpu;
 using GHelper.Helpers;
 using GHelper.Input;
+using GHelper.Mcp;
 using GHelper.Mode;
 using GHelper.Overlay;
 using GHelper.Peripherals;
@@ -225,6 +226,9 @@ namespace GHelper
 
             if (AppConfig.Is("overlay"))
                 hardwareOverlay?.StartOverlay();
+
+            // Start the MCP server if the user has opted in (disabled by default).
+            McpServer.ApplyState();
 
             Application.Run();
         }
@@ -467,6 +471,7 @@ namespace GHelper
                 trayIcon.Dispose();
             }
 
+            McpServer.Stop();
             PeripheralsProvider.UnregisterForDeviceEvents();
             clamshellControl.UnregisterDisplayEvents();
             NativeMethods.UnregisterPowerSettingNotification(unRegPowerNotify);

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -887,6 +887,12 @@ namespace GHelper
             menuOverlay.Checked = AppConfig.Is("overlay");
             contextMenuStrip.Items.Add(menuOverlay);
 
+            var menuMcp = new ToolStripMenuItem("MCP Server");
+            menuMcp.Margin = padding;
+            menuMcp.Checked = GHelper.Mcp.McpServer.Enabled;
+            menuMcp.Click += (sender, args) => ToggleMcpServer(menuMcp);
+            contextMenuStrip.Items.Add(menuMcp);
+
             var quit = new ToolStripMenuItem(Properties.Strings.Quit);
             quit.Click += ButtonQuit_Click;
             quit.Margin = padding;
@@ -1679,6 +1685,26 @@ namespace GHelper
             else
                 Program.hardwareOverlay?.StopOverlay();
             SetContextMenu();
+        }
+
+        public void ToggleMcpServer(ToolStripMenuItem menuItem)
+        {
+            bool enable = !GHelper.Mcp.McpServer.Enabled;
+            GHelper.Mcp.McpServer.Enabled = enable;
+            GHelper.Mcp.McpServer.ApplyState();
+            menuItem.Checked = enable;
+
+            if (enable)
+            {
+                // Show the connection details once so the user can configure their MCP client.
+                string message =
+                    "MCP server enabled.\n\n" +
+                    "URL: " + GHelper.Mcp.McpServer.Url + "\n" +
+                    "Authorization: Bearer " + GHelper.Mcp.McpServer.Token + "\n\n" +
+                    "It accepts connections from this machine only. Anyone with the token above can " +
+                    "read sensors and change laptop settings, so keep it private.";
+                MessageBox.Show(message, "G-Helper MCP Server", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
         }
 
         public void ShowMode(int mode)

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -1,0 +1,103 @@
+# G-Helper MCP Server
+
+G-Helper can expose its laptop controls and telemetry to AI assistants through a built-in
+[Model Context Protocol](https://modelcontextprotocol.io) (MCP) server. Once enabled, an
+MCP client (Claude Desktop, Claude Code, or any other) can read sensors and change settings
+on your Asus laptop.
+
+The server is **disabled by default**. It runs inside the G-Helper process, listens on
+**localhost only**, and requires a **bearer token** on every request.
+
+## Enabling the server
+
+1. Right-click the G-Helper tray icon.
+2. Click **MCP Server** to toggle it on.
+3. A dialog shows the connection **URL** and **token** — copy them. The token is also stored
+   in `config.json` under `mcp_token`.
+
+> Because the server controls hardware (performance mode, GPU mode, battery limit, etc.),
+> binding to `http://127.0.0.1` requires permission to reserve the URL. G-Helper already runs
+> elevated for most hardware features, in which case it works out of the box. If the server
+> fails to start (see `log.txt`) while running unelevated, reserve the URL once as admin:
+>
+> ```powershell
+> netsh http add urlacl url=http://127.0.0.1:8787/ user=Everyone
+> ```
+
+### Configuration keys (`config.json`)
+
+| Key           | Default | Meaning                                      |
+| ------------- | ------- | -------------------------------------------- |
+| `mcp_enabled` | `0`     | `1` to start the server on launch.           |
+| `mcp_port`    | `8787`  | TCP port (loopback only).                    |
+| `mcp_token`   | (auto)  | Bearer token, auto-generated on first start. |
+
+## Transport
+
+The server implements the MCP **Streamable HTTP** transport at:
+
+```
+http://127.0.0.1:8787/mcp
+```
+
+Every request must include:
+
+- `Authorization: Bearer <mcp_token>`
+- `Accept: application/json, text/event-stream`
+
+The server returns single `application/json` JSON-RPC responses (it does not open
+server-initiated SSE streams). Cross-origin browser requests are rejected to prevent
+DNS-rebinding attacks.
+
+## Connecting from Claude Code
+
+```bash
+claude mcp add --transport http g-helper http://127.0.0.1:8787/mcp \
+  --header "Authorization: Bearer <mcp_token>"
+```
+
+## Connecting from Claude Desktop
+
+Add to your MCP config (replace the token):
+
+```json
+{
+  "mcpServers": {
+    "g-helper": {
+      "type": "http",
+      "url": "http://127.0.0.1:8787/mcp",
+      "headers": { "Authorization": "Bearer <mcp_token>" }
+    }
+  }
+}
+```
+
+## Available tools
+
+| Tool                     | Type    | Description                                                                  |
+| ------------------------ | ------- | ---------------------------------------------------------------------------- |
+| `get_status`             | read    | Model, performance mode, GPU mode, power source, battery, display, backlight |
+| `get_sensors`            | read    | CPU/GPU temperature, fan RPMs, CPU/GPU power draw                            |
+| `list_performance_modes` | read    | Built-in and custom performance modes, plus the current one                  |
+| `set_performance_mode`   | control | `silent` \| `balanced` \| `turbo`                                            |
+| `set_gpu_mode`           | control | `eco` \| `standard` (Ultimate is excluded — it requires a reboot)            |
+| `set_battery_limit`      | control | Charge limit percentage (40–100)                                             |
+| `set_keyboard_backlight` | control | Backlight level 0–3                                                          |
+| `set_refresh_rate`       | control | Refresh rate in Hz (`0` = minimum, `1000` = maximum)                         |
+
+## Security notes
+
+- Anyone with the token can read sensors and change laptop settings. Treat it like a password.
+- The server only accepts connections from the local machine (`127.0.0.1`).
+- Toggling the tray menu item off stops the server immediately.
+- To rotate the token, delete `mcp_token` from `config.json` and re-enable the server.
+
+## Implementation
+
+The server lives in [`app/Mcp/`](../app/Mcp):
+
+- `McpServer.cs` — `HttpListener`-based transport, auth, Origin validation, session handling.
+- `McpProtocol.cs` — JSON-RPC 2.0 framing and `initialize` / `tools/list` / `tools/call` dispatch.
+- `McpTools.cs` — the tool definitions wrapping G-Helper's existing controllers.
+
+It adds **no new NuGet dependencies**.


### PR DESCRIPTION
Expose G-Helper telemetry and controls to MCP clients (Claude Desktop / Claude Code) via an in-process Model Context Protocol server.

- Streamable HTTP transport on HttpListener (no new dependencies), bound to 127.0.0.1, with bearer-token auth and Origin validation.
- JSON-RPC 2.0 dispatch: initialize / tools/list / tools/call / ping.
- 8 tools wrapping existing controllers: get_status, get_sensors, list_performance_modes, set_performance_mode, set_gpu_mode, set_battery_limit, set_keyboard_backlight, set_refresh_rate.
- Tool handlers marshaled onto the UI thread for safe WinForms/ACPI access.
- Disabled by default; opt-in via tray menu (shows URL + token) or the mcp_enabled config flag. Token auto-generated and persisted.
- Docs in docs/MCP.md.