### PR TITLE
Fix mouse settings page slider logic

### DIFF
--- a/app/AsusMouseSettings.cs
+++ b/app/AsusMouseSettings.cs
@@ -80,6 +80,7 @@ namespace GHelper
             numericUpDownCurrentDPI.ValueChanged += NumericUpDownCurrentDPI_ValueChanged;
             sliderDPI.MouseUp += SliderDPI_MouseUp;
             sliderDPI.MouseDown += SliderDPI_MouseDown;
+            sliderDPI.KeyReleased += SliderDPI_KeyReleased;
             buttonDPIColor.Click += ButtonDPIColor_Click;
             buttonDPI1.Click += ButtonDPI_Click;
             buttonDPI2.Click += ButtonDPI_Click;
@@ -572,7 +573,6 @@ namespace GHelper
         private void SliderDPI_ValueChanged(object? sender, EventArgs e)
         {
             numericUpDownCurrentDPI.Value = sliderDPI.Value;
-            UpdateMouseDPISettings();
         }
 
         private void NumericUpDownCurrentDPI_ValueChanged(object? sender, EventArgs e)
@@ -588,6 +588,11 @@ namespace GHelper
         private void SliderDPI_MouseUp(object? sender, MouseEventArgs e)
         {
             updateMouseDPI = true;
+            UpdateMouseDPISettings();
+        }
+
+        private void SliderDPI_KeyReleased(object? sender, KeyEventArgs e)
+        {
             UpdateMouseDPISettings();
         }
 

--- a/app/AsusMouseSettings.cs
+++ b/app/AsusMouseSettings.cs
@@ -100,7 +100,6 @@ namespace GHelper
             sliderAngleAdjustment.MouseUp += SliderAngleAdjustment_MouseUp;
             comboBoxLiftOffDistance.DropDownClosed += ComboBoxLiftOffDistance_DropDownClosed;
             sliderButtonDebounce.ValueChanged += SliderButtonDebounce_ValueChanged;
-            sliderButtonDebounce.MouseUp += SliderButtonDebounce_MouseUp;
 
             checkBoxMotionSync.CheckedChanged += CheckBoxMotionSync_CheckedChanged;
             checkBoxZoneMode.CheckedChanged += CheckBoxZoneMode_CheckedChanged;
@@ -117,7 +116,7 @@ namespace GHelper
 
             buttonLightingColor.Click += ButtonLightingColor_Click;
             comboBoxLightingMode.DropDownClosed += ComboBoxLightingMode_DropDownClosed;
-            sliderBrightness.MouseUp += SliderBrightness_MouseUp;
+            sliderBrightness.ValueChanged += SliderBrightness_ValueChanged;
             comboBoxAnimationSpeed.DropDownClosed += ComboBoxAnimationSpeed_DropDownClosed;
             comboBoxAnimationDirection.DropDownClosed += ComboBoxAnimationDirection_DropDownClosed;
             checkBoxRandomColor.CheckedChanged += CheckBoxRandomColor_CheckedChanged;
@@ -170,17 +169,11 @@ namespace GHelper
             labelDecelerationValue.Text = sliderDeceleration.Value.ToString();
         }
 
-        private void SliderButtonDebounce_MouseUp(object? sender, MouseEventArgs e)
-        {
-            DebounceTime dbt = (DebounceTime)sliderButtonDebounce.Value;
-            mouse.SetDebounce(dbt);
-        }
-
         private void SliderButtonDebounce_ValueChanged(object? sender, EventArgs e)
         {
             DebounceTime dbt = (DebounceTime)sliderButtonDebounce.Value;
             int time = mouse.DebounceTimeInMS(dbt);
-
+            mouse.SetDebounce(dbt);
             labelButtonDebounceValue.Text = time + "ms";
         }
 
@@ -436,7 +429,7 @@ namespace GHelper
             UpdateLightingSettings(ls, visibleZone);
         }
 
-        private void SliderBrightness_MouseUp(object? sender, MouseEventArgs e)
+        private void SliderBrightness_ValueChanged(object? sender, EventArgs e)
         {
             LightingSetting? ls = mouse.LightingSettingForZone(visibleZone);
             ls.Brightness = sliderBrightness.Value;

--- a/app/UI/Slider.cs
+++ b/app/UI/Slider.cs
@@ -31,6 +31,7 @@ namespace GHelper.UI
         public Color borderColor = Color.White;
 
         public event EventHandler ValueChanged;
+        public event KeyEventHandler KeyReleased;
 
         public Slider()
         {
@@ -123,6 +124,21 @@ namespace GHelper.UI
             AccessibilityNotifyClients(AccessibleEvents.Focus, 0);
 
             base.OnKeyDown(e);
+        }
+
+        protected override void OnKeyUp(KeyEventArgs e)
+        {
+            switch (e.KeyCode)
+            {
+                case Keys.Right:
+                case Keys.Up:
+                case Keys.Left:
+                case Keys.Down:
+                    KeyReleased?.Invoke(this, e);
+                    break;
+            }
+
+            base.OnKeyUp(e);
         }
 
         protected override void OnPaint(PaintEventArgs e)


### PR DESCRIPTION
# Issue
- Mouse Brightness and debounce sliders update their values only if the mouse is used, entirely ignoring keyboard input.

https://github.com/user-attachments/assets/0b1c61f5-6848-43fe-8133-ececfe6f6a8e

# Fix
+ Changed mouse brightness and debounce sliders to trigger update regardless of mouse or keyboard input.

https://github.com/user-attachments/assets/3b692165-86ed-4f98-a7f8-c053a1fb722b