### PR TITLE
fix(AppConfig): prevent config loss on unclean shutdown

### DIFF
--- a/app/AppConfig.cs
+++ b/app/AppConfig.cs
@@ -90,7 +90,7 @@ public static class AppConfig
         try
         {
             WriteAtomic(configFile, jsonString);
-            SyncFallbackConfig();
+            SyncFallbackConfig(jsonString);
         }
         catch (Exception ex) { Logger.WriteLine("Config write failed: " + ex.Message); }
     }
@@ -107,13 +107,14 @@ public static class AppConfig
             File.Move(tmp, path);
     }
 
-    private static void SyncFallbackConfig()
+    private static void SyncFallbackConfig(string content)
     {
         if (fallbackConfigFile is null || fallbackConfigFile == configFile) return;
+        if (string.IsNullOrWhiteSpace(content) || content.IndexOf('\0') >= 0) return;
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(fallbackConfigFile));
-            File.Copy(configFile, fallbackConfigFile, overwrite: true);
+            WriteAtomic(fallbackConfigFile, content);
         }
         catch (Exception ex)
         {
@@ -231,19 +232,32 @@ public static class AppConfig
 
     public static void Set(string name, int value)
     {
-        lock (configLock) config[name] = value;
+        lock (configLock)
+        {
+            if (config.TryGetValue(name, out var cur) && cur is not null
+                && int.TryParse(cur.ToString(), out int curInt) && curInt == value) return;
+            config[name] = value;
+        }
         Write();
     }
 
     public static void Set(string name, string value)
     {
-        lock (configLock) config[name] = value;
+        lock (configLock)
+        {
+            if (config.TryGetValue(name, out var cur) && cur?.ToString() == value) return;
+            config[name] = value;
+        }
         Write();
     }
 
     public static void Remove(string name)
     {
-        lock (configLock) config.Remove(name);
+        lock (configLock)
+        {
+            if (!config.ContainsKey(name)) return;
+            config.Remove(name);
+        }
         Write();
     }
 


### PR DESCRIPTION
**Problem**

Asus TUF/Tian Xuan laptops have a long-standing hardware bug: opening the lid from sleep can trigger a spontaneous hard reboot — essentially a sudden power loss.

G-Helper's config write logic had a flaw: **any call to `Set()` would schedule a disk write after 2 seconds, regardless of whether the value actually changed.** Lid-open events fire a cascade of system events (monitor wake, power state changes, mode re-application) that all call `Set()`, but most of them write the exact same values already in memory.

The result: **lid-open = trigger disk write + trigger reboot**, both dangerous operations tied to the same user action. The reboot lands during that brief write window, corrupting both `config.json` and its `.bak` backup into 0x00 bytes. Next launch sees both files trashed, falls through all recovery paths, and resets everything to defaults.

**Fix (Two layers)**

**Layer 1: Dirty-check before writing**

Added a value-comparison guard in `Set()` / `Remove()`. If the new value equals the existing one, skip the write entirely. This eliminates the vast majority of redundant disk writes triggered by system events, drastically reducing the chance of a crash mid-write.

**Layer 2: Harden the fallback backup**

Previously `SyncFallbackConfig` used `File.Copy(source, fallback)`, meaning a corrupted primary file would silently overwrite and destroy the backup copy.

Now it receives the freshly serialized JSON string (guaranteed valid) and writes it atomically via `WriteAtomic`. An additional guard aborts the write if the JSON string is empty or contains NUL bytes, preventing the fallback from being poisoned by corrupted data from the primary file.