### PR TITLE
AMD boost profile

### DIFF
--- a/app/Fans.Designer.cs
+++ b/app/Fans.Designer.cs
@@ -31,6 +31,7 @@ namespace GHelper
         /// </summary>
         private void InitializeComponent()
         {
+            components = new System.ComponentModel.Container();
             ChartArea chartArea1 = new ChartArea();
             Title title1 = new Title();
             ChartArea chartArea2 = new ChartArea();
@@ -97,6 +98,14 @@ namespace GHelper
             panelTitleTemp = new Panel();
             pictureTemp = new PictureBox();
             labelTempLimit = new Label();
+            panelTitleAmdProfile = new Panel();
+            pictureAmdProfile = new PictureBox();
+            labelTitleAmdProfile = new Label();
+            pictureAmdProfileHelp = new PictureBox();
+            panelAmdProfile = new Panel();
+            comboAmdProfile = new RComboBox();
+            panelAmdProfileDivider = new Panel();
+            toolTip = new ToolTip(components);
             panelDownload = new Panel();
             buttonDownload = new RButton();
             panelPawnIO = new Panel();
@@ -193,6 +202,10 @@ namespace GHelper
             ((System.ComponentModel.ISupportInitialize)trackTemp).BeginInit();
             panelTitleTemp.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)pictureTemp).BeginInit();
+            panelTitleAmdProfile.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)pictureAmdProfile).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)pictureAmdProfileHelp).BeginInit();
+            panelAmdProfile.SuspendLayout();
             panelDownload.SuspendLayout();
             panelPawnIO.SuspendLayout();
             panelPower.SuspendLayout();
@@ -787,7 +800,6 @@ namespace GHelper
             labelRisky.BackColor = Color.IndianRed;
             labelRisky.Dock = DockStyle.Top;
             labelRisky.ForeColor = SystemColors.ControlLightLight;
-            labelRisky.Location = new Point(0, 608);
             labelRisky.Margin = new Padding(0);
             labelRisky.Name = "labelRisky";
             labelRisky.Padding = new Padding(10, 10, 10, 5);
@@ -896,7 +908,6 @@ namespace GHelper
             panelTitleAdvanced.Controls.Add(pictureUV);
             panelTitleAdvanced.Controls.Add(labelTitleUV);
             panelTitleAdvanced.Dock = DockStyle.Top;
-            panelTitleAdvanced.Location = new Point(0, 294);
             panelTitleAdvanced.Name = "panelTitleAdvanced";
             panelTitleAdvanced.Size = new Size(520, 66);
             panelTitleAdvanced.TabIndex = 2;
@@ -917,7 +928,7 @@ namespace GHelper
             // 
             labelTitleUV.AutoSize = true;
             labelTitleUV.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
-            labelTitleUV.Location = new Point(43, 17);
+            labelTitleUV.Location = new Point(46, 18);
             labelTitleUV.Margin = new Padding(4, 0, 4, 0);
             labelTitleUV.Name = "labelTitleUV";
             labelTitleUV.Size = new Size(166, 32);
@@ -934,9 +945,11 @@ namespace GHelper
             panelTemperature.Dock = DockStyle.Top;
             panelTemperature.Location = new Point(0, 170);
             panelTemperature.Margin = new Padding(4);
-            panelTemperature.MaximumSize = new Size(0, 124);
+            panelTemperature.MaximumSize = new Size(0, 100);
+            panelTemperature.MinimumSize = new Size(0, 100);
             panelTemperature.Name = "panelTemperature";
-            panelTemperature.Size = new Size(520, 124);
+            panelTemperature.Padding = new Padding(0, 0, 0, 12);
+            panelTemperature.Size = new Size(520, 100);
             panelTemperature.TabIndex = 1;
             // 
             // labelTemp
@@ -977,17 +990,16 @@ namespace GHelper
             panelTitleTemp.Controls.Add(pictureTemp);
             panelTitleTemp.Controls.Add(labelTempLimit);
             panelTitleTemp.Dock = DockStyle.Top;
-            panelTitleTemp.Location = new Point(0, 104);
+            panelTitleTemp.MinimumSize = new Size(0, 88);
             panelTitleTemp.Name = "panelTitleTemp";
-            panelTitleTemp.Size = new Size(520, 66);
+            panelTitleTemp.Size = new Size(520, 88);
             panelTitleTemp.TabIndex = 0;
-            // 
             // pictureTemp
             // 
             pictureTemp.BackgroundImage = Properties.Resources.icons8_temperature_32;
             pictureTemp.BackgroundImageLayout = ImageLayout.Zoom;
             pictureTemp.InitialImage = null;
-            pictureTemp.Location = new Point(10, 18);
+            pictureTemp.Location = new Point(10, 40);
             pictureTemp.Margin = new Padding(4, 2, 4, 10);
             pictureTemp.Name = "pictureTemp";
             pictureTemp.Size = new Size(32, 32);
@@ -998,12 +1010,91 @@ namespace GHelper
             // 
             labelTempLimit.AutoSize = true;
             labelTempLimit.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
-            labelTempLimit.Location = new Point(46, 17);
+            labelTempLimit.Location = new Point(46, 40);
             labelTempLimit.Margin = new Padding(4, 0, 4, 0);
             labelTempLimit.Name = "labelTempLimit";
             labelTempLimit.Size = new Size(140, 32);
             labelTempLimit.TabIndex = 47;
             labelTempLimit.Text = "Temp Limit";
+            // 
+            // panelTitleAmdProfile
+            // 
+            panelTitleAmdProfile.AutoSize = true;
+            panelTitleAmdProfile.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+            panelTitleAmdProfile.Controls.Add(pictureAmdProfileHelp);
+            panelTitleAmdProfile.Controls.Add(pictureAmdProfile);
+            panelTitleAmdProfile.Controls.Add(labelTitleAmdProfile);
+            panelTitleAmdProfile.Dock = DockStyle.Top;
+            panelTitleAmdProfile.Margin = new Padding(4);
+            panelTitleAmdProfile.Name = "panelTitleAmdProfile";
+            panelTitleAmdProfile.Size = new Size(520, 60);
+            panelTitleAmdProfile.TabIndex = 8;
+            // 
+            // pictureAmdProfile
+            // 
+            pictureAmdProfile.BackgroundImage = Properties.Resources.icons8_gauge_32;
+            pictureAmdProfile.BackgroundImageLayout = ImageLayout.Zoom;
+            pictureAmdProfile.Location = new Point(10, 18);
+            pictureAmdProfile.Margin = new Padding(4, 2, 4, 10);
+            pictureAmdProfile.Name = "pictureAmdProfile";
+            pictureAmdProfile.Size = new Size(32, 32);
+            pictureAmdProfile.TabIndex = 48;
+            pictureAmdProfile.TabStop = false;
+            // 
+            // labelTitleAmdProfile
+            // 
+            labelTitleAmdProfile.AutoSize = true;
+            labelTitleAmdProfile.Font = new Font("Segoe UI", 9F, FontStyle.Bold);
+            labelTitleAmdProfile.Location = new Point(46, 18);
+            labelTitleAmdProfile.Margin = new Padding(4, 0, 4, 0);
+            labelTitleAmdProfile.Name = "labelTitleAmdProfile";
+            labelTitleAmdProfile.Size = new Size(220, 32);
+            labelTitleAmdProfile.TabIndex = 47;
+            labelTitleAmdProfile.Text = "AMD Boost Profile";
+            // 
+            // pictureAmdProfileHelp
+            // 
+            pictureAmdProfileHelp.Anchor = AnchorStyles.Top | AnchorStyles.Right;
+            pictureAmdProfileHelp.BackgroundImage = Properties.Resources.icons8_help_32;
+            pictureAmdProfileHelp.BackgroundImageLayout = ImageLayout.Zoom;
+            pictureAmdProfileHelp.Cursor = Cursors.Hand;
+            pictureAmdProfileHelp.Location = new Point(478, 17);
+            pictureAmdProfileHelp.Margin = new Padding(5, 3, 5, 3);
+            pictureAmdProfileHelp.Name = "pictureAmdProfileHelp";
+            pictureAmdProfileHelp.Size = new Size(32, 32);
+            pictureAmdProfileHelp.TabIndex = 49;
+            pictureAmdProfileHelp.TabStop = false;
+            // 
+            // panelAmdProfile
+            // 
+            panelAmdProfile.Controls.Add(comboAmdProfile);
+            panelAmdProfile.Dock = DockStyle.Top;
+            panelAmdProfile.Margin = new Padding(4);
+            panelAmdProfile.MinimumSize = new Size(0, 76);
+            panelAmdProfile.Name = "panelAmdProfile";
+            panelAmdProfile.Size = new Size(520, 76);
+            panelAmdProfile.TabIndex = 10;
+            // 
+            // comboAmdProfile
+            // 
+            comboAmdProfile.Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right;
+            comboAmdProfile.BorderColor = Color.White;
+            comboAmdProfile.ButtonColor = Color.FromArgb(255, 255, 255);
+            comboAmdProfile.DropDownStyle = ComboBoxStyle.DropDownList;
+            comboAmdProfile.FormattingEnabled = true;
+            comboAmdProfile.Location = new Point(13, 12);
+            comboAmdProfile.Margin = new Padding(4);
+            comboAmdProfile.Name = "comboAmdProfile";
+            comboAmdProfile.Size = new Size(329, 40);
+            comboAmdProfile.TabIndex = 0;
+            // 
+            // panelAmdProfileDivider
+            // 
+            panelAmdProfileDivider.Dock = DockStyle.Top;
+            panelAmdProfileDivider.Margin = new Padding(0);
+            panelAmdProfileDivider.Name = "panelAmdProfileDivider";
+            panelAmdProfileDivider.Size = new Size(520, 3);
+            panelAmdProfileDivider.TabIndex = 11;
             // 
             // panelDownload
             // 
@@ -1021,6 +1112,9 @@ namespace GHelper
             panelPawnIO.Controls.Add(panelTitleAdvanced);
             panelPawnIO.Controls.Add(panelTemperature);
             panelPawnIO.Controls.Add(panelTitleTemp);
+            panelPawnIO.Controls.Add(panelAmdProfileDivider);
+            panelPawnIO.Controls.Add(panelAmdProfile);
+            panelPawnIO.Controls.Add(panelTitleAmdProfile);
             panelPawnIO.Dock = DockStyle.Top;
             panelPawnIO.Name = "panelPawnIO";
             panelPawnIO.TabIndex = 1;
@@ -1933,6 +2027,11 @@ namespace GHelper
             panelTitleTemp.ResumeLayout(false);
             panelTitleTemp.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)pictureTemp).EndInit();
+            panelTitleAmdProfile.ResumeLayout(false);
+            panelTitleAmdProfile.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)pictureAmdProfile).EndInit();
+            ((System.ComponentModel.ISupportInitialize)pictureAmdProfileHelp).EndInit();
+            panelAmdProfile.ResumeLayout(false);
             panelDownload.ResumeLayout(false);
             panelDownload.PerformLayout();
             panelPawnIO.ResumeLayout(false);
@@ -2118,5 +2217,13 @@ namespace GHelper
         private RTrackBar trackHysteresisDown;
         private Label labelHysteresisUpValue;
         private Label labelHysteresisDownValue;
+        private Panel panelTitleAmdProfile;
+        private PictureBox pictureAmdProfile;
+        private Label labelTitleAmdProfile;
+        private PictureBox pictureAmdProfileHelp;
+        private Panel panelAmdProfile;
+        private RComboBox comboAmdProfile;
+        private Panel panelAmdProfileDivider;
+        private ToolTip toolTip;
     }
 }

--- a/app/Fans.cs
+++ b/app/Fans.cs
@@ -41,6 +41,7 @@ namespace GHelper
         static int gpuPowerBase = 0;
         static bool isGPUPower => gpuPowerBase > 0;
         static bool clampFanDots = AppConfig.IsClampFanDots();
+        bool amdProfileLoading;
 
         public Fans()
         {
@@ -81,6 +82,9 @@ namespace GHelper
             labelHysteresisDown.Text = Properties.Strings.HysteresisDown;
             buttonReadLimits.Text = Properties.Strings.ReadLimits;
             buttonDownload.Text = Properties.Strings.InstallPawnIODriver;
+
+            labelTitleAmdProfile.Text = Properties.Strings.AmdBoostProfileTitle;
+            toolTip.SetToolTip(pictureAmdProfileHelp, Properties.Strings.AmdProfileHint);
 
             InitTheme(true);
 
@@ -234,12 +238,20 @@ namespace GHelper
             comboPowerMode.DisplayMember = "Value";
             comboPowerMode.ValueMember = "Key";
 
+            comboAmdProfile.DropDownStyle = ComboBoxStyle.DropDownList;
+            comboAmdProfile.Items.AddRange([
+                Properties.Strings.AmdProfileDefault,
+                Properties.Strings.AmdProfilePowerSaving,
+                Properties.Strings.AmdProfileMaxPerformance
+            ]);
+
             FillModes(false);
             InitAll();
             InitCPU();
 
             comboBoost.SelectedValueChanged += ComboBoost_Changed;
             comboPowerMode.SelectedValueChanged += ComboPowerMode_Changed;
+            comboAmdProfile.SelectedIndexChanged += ComboAmdProfile_Changed;
 
 
             comboModes.SelectionChangeCommitted += ComboModes_SelectedValueChanged;
@@ -451,6 +463,8 @@ namespace GHelper
 
             VisualiseAdvanced();
 
+            if (ModeControl.IsAmdPowerProfileSupported()) VisualiseAmdProfile();
+
             buttonAdvanced.Visible = CpuInfo.IsAMD;
 
         }
@@ -462,6 +476,13 @@ namespace GHelper
 
             panelPawnIO.Visible   = installed;
             panelDownload.Visible = !installed;
+
+            bool profileSupported = CpuInfo.IsAMD && ModeControl.IsAmdPowerProfileSupported();
+            panelTitleAmdProfile.Visible = profileSupported;
+            pictureAmdProfileHelp.Visible = profileSupported;
+            panelAmdProfile.Visible = profileSupported;
+            panelAmdProfileDivider.Visible = profileSupported;
+            panelAmdProfileDivider.BackColor = borderMain;
 
             if (installed)
             {
@@ -475,6 +496,22 @@ namespace GHelper
             labelUViGPU.Text = trackUViGPU.Value.ToString();
 
             labelTemp.Text = (trackTemp.Value < CpuInfo.DefaultTemp) ? TempHelper.FormatTemp(trackTemp.Value) : "Default";
+
+            if (profileSupported) VisualiseAmdProfile();
+        }
+
+        private void VisualiseAmdProfile()
+        {
+            amdProfileLoading = true;
+            comboAmdProfile.SelectedIndex = (int)ModeControl.GetConfiguredProfile();
+            amdProfileLoading = false;
+        }
+
+        private void ComboAmdProfile_Changed(object? sender, EventArgs e)
+        {
+            if (amdProfileLoading || comboAmdProfile.SelectedIndex < 0) return;
+            AppConfig.SetMode("amd_boost_profile", comboAmdProfile.SelectedIndex);
+            modeControl.SetAmdProfile(true);
         }
 
         private void AdvancedScroll()
@@ -1276,6 +1313,13 @@ namespace GHelper
 
             AdvancedScroll();
             AppConfig.RemoveMode("cpu_temp");
+
+            AppConfig.SetMode("amd_boost_profile", 0);
+            if (ModeControl.IsAmdPowerProfileSupported())
+            {
+                VisualiseAmdProfile();
+                modeControl.SetAmdProfile();
+            }
 
             modeControl.ResetPerformanceMode();
 

--- a/app/Mode/ModeControl.cs
+++ b/app/Mode/ModeControl.cs
@@ -17,6 +17,8 @@ namespace GHelper.Mode
         private int _igpuUV = 0;
         private int _cpuTemp = CpuInfo.DefaultTemp;
         private bool _ryzenPower = false;
+        private AmdPowerProfile _amdProfile = AmdPowerProfile.Default;
+        private bool _amdProfileSynced = false;
 
         private static RyzenSmuService? _smu;
         private static readonly object _smuLock = new();
@@ -43,6 +45,11 @@ namespace GHelper.Mode
 
         public static bool IsPawnAvailable()  => GetSmu() != null;
         public static bool IsPawnInstalled()   => RyzenSmuService.IsPawnInstalled();
+        public static bool IsAmdPowerProfileSupported()
+        {
+            var smu = GetSmu();
+            return smu != null && smu.CanSetPowerProfile();
+        }
 
         static System.Timers.Timer? reapplyTimer;
         static System.Timers.Timer modeToggleTimer = default!;
@@ -303,6 +310,7 @@ namespace GHelper.Mode
             Thread.Sleep(500);
             SetGPUPower();
             AutoRyzen();
+            ApplyConfiguredAmdProfile();
 
             if (IsReapplyRyzenRequired())
                 Task.Delay(5000).ContinueWith(_ => { AutoRyzen(); ReadRyzenLimits(); });
@@ -492,6 +500,87 @@ namespace GHelper.Mode
                 Logger.WriteLine($"iGPU UV: {igpuUV} {status}");
                 if (status == SmuStatus.OK) _igpuUV = igpuUV;
             }
+        }
+
+        public static AmdPowerProfile ResolveAmdProfile(AmdPowerProfile profile)
+        {
+            if (profile != AmdPowerProfile.Default) return profile;
+            return Program.ReadPowerSource() == Program.PowerSource.Battery
+                ? AmdPowerProfile.PowerSaving
+                : AmdPowerProfile.MaxPerformance;
+        }
+
+        private SmuStatus? ApplyAmdProfileInternal(AmdPowerProfile profile, bool log)
+        {
+            if (!ProcessHelper.IsUserAdministrator()) return null;
+
+            var smu = GetSmu();
+            if (smu == null || !smu.CanSetPowerProfile()) return null;
+
+            AmdPowerProfile toApply = profile == AmdPowerProfile.Default
+                ? ResolveAmdProfile(profile)
+                : profile;
+            SmuStatus status = smu.SetPowerProfile(toApply);
+            if (status == SmuStatus.OK)
+            {
+                _amdProfile = profile;
+                _amdProfileSynced = true;
+            }
+            if (log)
+            {
+                string label = profile == AmdPowerProfile.Default
+                    ? $"Default -> {toApply}"
+                    : profile.ToString();
+                Logger.WriteLine($"AMD Profile: {label} {status}");
+            }
+            return status;
+        }
+
+        public static AmdPowerProfile GetConfiguredProfile()
+        {
+            int profileValue = AppConfig.GetMode("amd_boost_profile", 0);
+            if (profileValue < 0 || profileValue > 2) profileValue = 0;
+            return (AmdPowerProfile)profileValue;
+        }
+
+        public SmuStatus? ApplyAmdProfile(bool log = false)
+        {
+            return ApplyAmdProfileInternal(GetConfiguredProfile(), log);
+        }
+
+        public void ApplyConfiguredAmdProfile(bool log = true)
+        {
+            if (!CpuInfo.IsAMD || !IsAmdPowerProfileSupported()) return;
+
+            var configured = GetConfiguredProfile();
+            if (configured == AmdPowerProfile.Default)
+            {
+                if (!_amdProfileSynced || _amdProfile != AmdPowerProfile.Default)
+                    ApplyAmdProfileInternal(AmdPowerProfile.Default, log);
+                return;
+            }
+
+            ApplyAmdProfile(log);
+        }
+
+        public string SetAmdProfile(bool launchAsAdmin = false)
+        {
+            if (!ProcessHelper.IsUserAdministrator())
+            {
+                if (launchAsAdmin) ProcessHelper.RunAsAdmin("amdprofile");
+                return string.Empty;
+            }
+
+            if (!CpuInfo.IsAMD || !IsAmdPowerProfileSupported()) return string.Empty;
+
+            SmuStatus? status = ApplyAmdProfile(true);
+            if (!status.HasValue) return string.Empty;
+
+            var profile = GetConfiguredProfile();
+            string label = profile == AmdPowerProfile.Default
+                ? $"Default -> {ResolveAmdProfile(profile)}"
+                : profile.ToString();
+            return $"AMD Profile {label}: {status}";
         }
 
         public string SetRyzen(bool launchAsAdmin = false)

--- a/app/Mode/Modes.cs
+++ b/app/Mode/Modes.cs
@@ -23,6 +23,7 @@
             { "cpu_temp", "_" },
             { "cpu_uv", "_" },
             { "igpu_uv", "_" },
+            { "amd_boost_profile", "int" },
             { "auto_boost", "int" },
             { "auto_apply", "int" },
             { "auto_apply_power", "int" },

--- a/app/Pawn/RyzenSmu.cs
+++ b/app/Pawn/RyzenSmu.cs
@@ -15,6 +15,13 @@ namespace PawnIO
         CmdRejectedBusy   = 0xFC,
     }
 
+    public enum AmdPowerProfile
+    {
+        Default = 0,
+        PowerSaving = 1,
+        MaxPerformance = 2,
+    }
+
     public enum CpuCodeName : uint
     {
         Undefined     = 0xFFFFFFFF,
@@ -145,6 +152,8 @@ namespace PawnIO
         public bool CanSetTDP()   => _cpu is not CpuCodeName.Undefined;
         public bool CanSetCoAll() => _cpu is not CpuCodeName.Undefined;
         public bool CanSetThm()   => _cpu is not CpuCodeName.Undefined;
+        public bool CanSetPowerProfile() => Family is CpuFamily.Raven or CpuFamily.Renoir
+            or CpuFamily.Mobile or CpuFamily.StrixPoint or CpuFamily.StrixHalo;
 
         public bool SetAllLimits(int stapmW, int fastW, int slowW)
             => SetStapm(stapmW) == SmuStatus.OK & SetFast(fastW) == SmuStatus.OK & SetSlow(slowW) == SmuStatus.OK;
@@ -204,6 +213,33 @@ namespace PawnIO
                 // RyzenAdj: _do_adjust(0x3F) — MP1 only
                 CpuFamily.Raphael                        => SendMp1(0x3F, v),
                 _                                        => SmuStatus.Failed,
+            };
+        }
+
+        public SmuStatus SetPowerProfile(AmdPowerProfile profile)
+        {
+            if (profile == AmdPowerProfile.Default)
+                return SmuStatus.OK;
+
+            return profile switch
+            {
+                AmdPowerProfile.MaxPerformance => Family switch
+                {
+                    // set_max_performance
+                    CpuFamily.Raven => SendMp1(0x18, 0),
+                    CpuFamily.Renoir or CpuFamily.Mobile
+                    or CpuFamily.StrixPoint or CpuFamily.StrixHalo => SendMp1(0x11, 0),
+                    _ => SmuStatus.Failed,
+                },
+                AmdPowerProfile.PowerSaving => Family switch
+                {
+                    // set_power_saving
+                    CpuFamily.Raven => SendMp1(0x19, 0),
+                    CpuFamily.Renoir or CpuFamily.Mobile
+                    or CpuFamily.StrixPoint or CpuFamily.StrixHalo => SendMp1(0x12, 0),
+                    _ => SmuStatus.Failed,
+                },
+                _ => SmuStatus.Failed,
             };
         }
 

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -203,6 +203,11 @@ namespace GHelper
                     settingsForm.FansToggle(2);
                     modeControl.SetRyzen();
                     break;
+                case "amdprofile":
+                    Startup.ReScheduleAdmin();
+                    settingsForm.FansToggle(2);
+                    modeControl.SetAmdProfile();
+                    break;
                 case "colors":
                     Task.Run(async () =>
                     {

--- a/app/Properties/Strings.Designer.cs
+++ b/app/Properties/Strings.Designer.cs
@@ -187,6 +187,51 @@ namespace GHelper.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to AMD Boost Profile.
+        /// </summary>
+        internal static string AmdBoostProfileTitle {
+            get {
+                return ResourceManager.GetString("AmdBoostProfileTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Default.
+        /// </summary>
+        internal static string AmdProfileDefault {
+            get {
+                return ResourceManager.GetString("AmdProfileDefault", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Default follows power source: max performance on charger, power saving on battery.
+        /// </summary>
+        internal static string AmdProfileHint {
+            get {
+                return ResourceManager.GetString("AmdProfileHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Max Performance.
+        /// </summary>
+        internal static string AmdProfileMaxPerformance {
+            get {
+                return ResourceManager.GetString("AmdProfileMaxPerformance", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Power Saving.
+        /// </summary>
+        internal static string AmdProfilePowerSaving {
+            get {
+                return ResourceManager.GetString("AmdProfilePowerSaving", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to App already running.
         /// </summary>
         internal static string AppAlreadyRunning {

--- a/app/Properties/Strings.resx
+++ b/app/Properties/Strings.resx
@@ -156,6 +156,21 @@
   <data name="AnimeMatrix" xml:space="preserve">
     <value>Anime Matrix</value>
   </data>
+  <data name="AmdBoostProfileTitle" xml:space="preserve">
+    <value>AMD Boost Profile</value>
+  </data>
+  <data name="AmdProfileDefault" xml:space="preserve">
+    <value>Default</value>
+  </data>
+  <data name="AmdProfileHint" xml:space="preserve">
+    <value>Default follows system AC/DC profile: max performance on charger, power saving on battery</value>
+  </data>
+  <data name="AmdProfileMaxPerformance" xml:space="preserve">
+    <value>Max Performance</value>
+  </data>
+  <data name="AmdProfilePowerSaving" xml:space="preserve">
+    <value>Power Saving</value>
+  </data>
   <data name="AppAlreadyRunning" xml:space="preserve">
     <value>App already running</value>
   </data>


### PR DESCRIPTION
@seerge An implementation of https://github.com/seerge/g-helper/discussions/4711
Tested on ROG Flow Z13 2025.

<img width="1176" height="1106" alt="image" src="https://github.com/user-attachments/assets/b4fc7213-c9d4-4ba1-a0c1-eb24fd1da204" />
