### PR TITLE
Improve bug issue template to prompt better log upload

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,10 +40,27 @@ body:
     id: logs
     attributes:
       label: Logs
-      placeholder: Please drag and drop complete log file from ``%APPDATA%\GHelper\log.txt``
-      description: Please drag and drop complete log file from ``%APPDATA%\GHelper\log.txt``
-    validations:
-      required: true
+      description: |
+        **Please do NOT paste the log directly, as it spams the issue.** 
+
+        **Recommended:** Drag and drop your `log.txt` file (from `%APPDATA%\GHelper\log.txt`) directly into this text box. 
+        GitHub will upload it as a clean attachment link.
+
+        **Fallback:** If you ABSOLUTELY cannot upload, paste your log inside a collapsed block:
+        ````markdown
+        <details>
+        <summary>Click to expand log</summary>
+
+        ```log
+        [paste log here]
+        ```
+
+        </details>
+        ````
+      placeholder: |
+        Drag your log.txt file here to upload it.
+        If you ABSOLUTELY cannot upload, paste your log inside a collapsed block shown above.
+        Respect the formate, and check by clicking "Preview" to make sure it looks correct.
   - type: input
     id: device
     attributes:

--- a/.github/ISSUE_TEMPLATE/peripherals_request.yml
+++ b/.github/ISSUE_TEMPLATE/peripherals_request.yml
@@ -20,8 +20,29 @@ body:
     id: solution
     attributes:
       label: USB Details
-      description: Also, please use <a href=https://www.uwe-sieber.de/usbtreeview.html>USB Tree View</a> and send the text (especially the block with all the child devices) of the mouse. <img width="1168" alt="image" src="https://github.com/seerge/g-helper/assets/12786283/8b51dd4d-c9fe-444e-b1b1-415175e10555">
-      placeholder: USB Tree View details
+      description: |
+        Please use <a href=https://www.uwe-sieber.de/usbtreeview.html>USB Tree View</a> and send the text (especially the block with all the child devices) of the mouse. <img width="1168" alt="image" src="https://github.com/seerge/g-helper/assets/12786283/8b51dd4d-c9fe-444e-b1b1-415175e10555">
+        Also, please make it a txt file then drag and drop it here as it will be uploaded as a attachment.
+        You can also paste the text in this template so it get folded :)
+        ````markdown
+        <details>
+        <summary>Click to expand text</summary>
+
+        ```log
+        [paste text here]
+        ```
+
+        </details>
+        ````
+      placeholder: |
+        <details>
+        <summary>Click to expand text</summary>
+
+        ```log
+        [paste USB Tree View details here]
+        ```
+
+        </details>
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Hi, I realized that many users did not chose to paste their logs as attatchments in the bug issues. The logs spamms the issue chain.

I added a prompt to encourage users to drag and drop their logs so it shows as link, and if they insist to paste, I provided a template to _fold_ the logs. Like this:

<details>
<summary>Click to expand log</summary>

```log
Log
Log
Log
Log
Log
```

</details>

And the issue template is rendered like this:
<img width="1724" height="886" alt="image" src="https://github.com/user-attachments/assets/831d292e-4869-4af8-a82f-67a90c459caa" />


Here's the markdown that does it:
````markdown
<details>
<summary>Click to expand log</summary>

```log
[paste log here]
```

</details>
````

Nothing significant, but some QoL changes that makes life better.