### PR TITLE
Fix missing GPU temperature on AMD iGPU-only models (Strix Halo / GZ302)

### DIFF
--- a/app/Gpu/AMD/AmdGpuControl.cs
+++ b/app/Gpu/AMD/AmdGpuControl.cs
@@ -69,7 +69,8 @@ public class AmdGpuControl : IGpuControl
 
     public AmdGpuControl()
     {
-        if (AppConfig.NoGpu() || !Adl2.Load()) return;
+        // AMD iGPU-only models (e.g. GZ302) still need ADL for iGPU sensors
+        if ((AppConfig.NoGpu() && !AppConfig.IsAMDiGPU()) || !Adl2.Load()) return;
 
         try
         {
@@ -201,7 +202,10 @@ public class AmdGpuControl : IGpuControl
     {
         if (!GetPMLogiGpu(out ADLPMLogDataOutput log)) return default;
 
-        return (Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_EDGE),
+        // Strix Halo (e.g. GZ302) doesn't report TEMPERATURE_EDGE; it exposes GFX/SOC instead
+        return (Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_EDGE)
+                ?? Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_GFX)
+                ?? Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_SOC),
                 Sensor(log, ADLSensorType.PMLOG_INFO_ACTIVITY_GFX),
                 Sensor(log, ADLSensorType.PMLOG_GFX_POWER),
                 Sensor(log, ADLSensorType.PMLOG_CPU_POWER),


### PR DESCRIPTION
On ROG Flow Z13 2025 (GZ302EA, Ryzen AI Max "Strix Halo", Radeon 8060S) G-Helper shows GPU fan RPM but no GPU temperature.

Two causes:

1. `AmdGpuControl`'s constructor returns early when `AppConfig.NoGpu()` is true, and GZ302 is on the NoGpu list — so ADL is never initialized and `GetiGpuSensors()` always returns nulls on this model. Changed the guard to still initialize ADL when `AppConfig.IsAMDiGPU()` is true, since those models need it for iGPU sensors.

2. `GetiGpuSensors()` reads `PMLOG_TEMPERATURE_EDGE`, which Strix Halo doesn't report (sensor unsupported in `ADL2_New_QueryPMLogData_Get` output). It exposes `PMLOG_TEMPERATURE_GFX` (28) and `PMLOG_TEMPERATURE_SOC` (29) instead. Added a fallback chain EDGE → GFX → SOC; devices that report EDGE (e.g. ROG Ally) are unaffected.

Verified on GZ302EA (Windows 11, Adrenalin 32.0.23033.5002): temperature now shows next to GPU fan speed and tracks load correctly (48°C idle → ~90°C under sustained GPU load), matching values read directly from the driver's PMLog interface. GPU usage and power readings on iGPU-only models also benefit from fix 1, as they go through the same `GetiGpuSensors()` path.