### PR TITLE
iGPU sensors for APU-only models

### DIFF
--- a/app/Gpu/AMD/AmdGpuControl.cs
+++ b/app/Gpu/AMD/AmdGpuControl.cs
@@ -69,7 +69,7 @@ public class AmdGpuControl : IGpuControl
 
     public AmdGpuControl()
     {
-        if (AppConfig.NoGpu() || !Adl2.Load()) return;
+        if ((AppConfig.NoGpu() && !AppConfig.IsAMDiGPU()) || !Adl2.Load()) return;
 
         try
         {
@@ -201,7 +201,9 @@ public class AmdGpuControl : IGpuControl
     {
         if (!GetPMLogiGpu(out ADLPMLogDataOutput log)) return default;
 
-        return (Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_EDGE),
+        return (Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_EDGE)
+                ?? Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_GFX)
+                ?? Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_SOC),
                 Sensor(log, ADLSensorType.PMLOG_INFO_ACTIVITY_GFX),
                 Sensor(log, ADLSensorType.PMLOG_GFX_POWER),
                 Sensor(log, ADLSensorType.PMLOG_CPU_POWER),

--- a/app/Overlay/HardwareOverlay.cs
+++ b/app/Overlay/HardwareOverlay.cs
@@ -148,6 +148,7 @@ namespace GHelper.Overlay
 
         // Cached drawing resources — recreated only when the scale changes
         private float _lastScale = 0f;
+        private float _charW;
         private Font? _font;
         private Font? _rpmFont;
         private Font? _fpsBold;
@@ -642,15 +643,14 @@ namespace GHelper.Overlay
                 _fpsBold?.Dispose(); _fpsBold = new Font("Consolas", innerH / 1.15f, FontStyle.Bold, GraphicsUnit.Pixel);
                 _totalPen?.Dispose(); _totalPen = new Pen(Color.FromArgb(255, 200, 200, 200), sc * 0.75f) { DashStyle = DashStyle.Dot };
                 _axPen?.Dispose();    _axPen    = new Pen(Color.FromArgb(255, 80, 80, 80), sc * 0.5f);
+                _charW = g.MeasureString("XX", _font).Width - g.MeasureString("X", _font).Width;
             }
 
             var font    = _font!;
             var rpmFont = _rpmFont!;
             var fpsBold = _fpsBold!;
 
-            // Differential trick: MeasureString("XX") - MeasureString("X") cancels the
-            // fixed GDI+ padding, giving the true per-character advance width for Consolas.
-            float charW = g.MeasureString("XX", font).Width - g.MeasureString("X", font).Width;
+            float charW = _charW;
 
             int topY = padY;
             // Nudge per-row text down so it lines up with the vertically centered usage bars.


### PR DESCRIPTION
<img width="1316" height="182" alt="image" src="https://github.com/user-attachments/assets/f8c26a08-ae1d-4234-9d83-72a66c03a1c9" />

 iGPU overlay support for AMD APU only GPUs + fixed FPS readings for apps that run on iGPU / Eco mode

[GHelper.zip](https://github.com/user-attachments/files/30166455/GHelper.zip)

