### PR TITLE
Optional fan sync to hottest sensor for shared heatsinks

### DIFF
--- a/app/Fan/FanMaxTempControl.cs
+++ b/app/Fan/FanMaxTempControl.cs
@@ -1,0 +1,111 @@
+namespace GHelper.Fan
+{
+    // EC firmware runs each fan off its own sensor (CPU fan - CPU temp, GPU fan - GPU temp).
+    // Since the heatsink is shared, this periodically raises the floor of every custom curve
+    // to the speed its own curve prescribes at the hottest sensor, so no fan idles while
+    // another component is hot. EC keeps reacting to its own sensor above the floor.
+    //
+    // Lifecycle: started by ModeControl.AutoFans after custom curves are successfully applied,
+    // stopped by AutoFans otherwise and by every path that resets EC curves behind its back
+    // (calibration, factory reset, sleep/shutdown reset).
+    public static class FanMaxTempControl
+    {
+        const int TICK_MS = 3000;
+        const int TEMP_STEP = 2;
+        const int NO_TEMP = -1000;
+
+        static readonly System.Timers.Timer timer = new(TICK_MS);
+        static readonly object syncLock = new();
+
+        static int lastTemp = NO_TEMP;
+        static readonly byte[]?[] lastWritten = new byte[3][];
+
+        static FanMaxTempControl()
+        {
+            timer.Elapsed += (s, e) =>
+            {
+                try { Tick(); }
+                catch (Exception ex) { Logger.WriteLine("FanSync: " + ex.Message); }
+            };
+        }
+
+        public static bool IsEnabled => AppConfig.Is("fan_sync_max_temp");
+
+        public static void Start()
+        {
+            lock (syncLock)
+            {
+                lastTemp = NO_TEMP;
+                Array.Clear(lastWritten);
+                if (timer.Enabled) return;
+                timer.Start();
+            }
+            Logger.WriteLine("FanSync: started");
+        }
+
+        public static void Stop()
+        {
+            lock (syncLock) // waits for an in-flight tick, so no floor write lands after Stop returns
+            {
+                if (!timer.Enabled) return;
+                timer.Stop();
+            }
+            Logger.WriteLine("FanSync: stopped");
+        }
+
+        static void Tick()
+        {
+            lock (syncLock)
+            {
+                if (!timer.Enabled) return;
+
+                int temp = -1;
+                float? cpu = HardwareControl.GetCPUTemp();
+                float? gpu = HardwareControl.GetGPUTemp();
+                if (cpu is > 0 and < 120) temp = (int)cpu;
+                if (gpu is > 0 and < 120 && (int)gpu > temp) temp = (int)gpu;
+                if (temp < 0) return;
+
+                if (Math.Abs(temp - lastTemp) < TEMP_STEP) return;
+                lastTemp = temp;
+
+                ApplyFloor(AsusFan.CPU, temp);
+                ApplyFloor(AsusFan.GPU, temp);
+                if (AppConfig.Is("mid_fan")) ApplyFloor(AsusFan.Mid, temp);
+            }
+        }
+
+        static void ApplyFloor(AsusFan device, int temp)
+        {
+            byte[] curve = AppConfig.GetFanConfig(device);
+            if (AsusACPI.IsInvalidCurve(curve)) return;
+
+            byte floor = EvalCurve(curve, temp);
+            for (int i = 8; i < 16; i++) curve[i] = Math.Max(curve[i], floor);
+
+            if (lastWritten[(int)device] is byte[] prev && prev.SequenceEqual(curve)) return;
+
+            byte[] written = (byte[])curve.Clone(); // SetFanCurve mutates the array (fan_scale)
+            lastWritten[(int)device] = Program.acpi.SetFanCurve(device, curve) == 1 ? written : null;
+        }
+
+        // Curve speed (%) at a given temperature, linearly interpolated between the 8 points
+        static byte EvalCurve(byte[] curve, int temp)
+        {
+            if (temp <= curve[0]) return curve[8];
+
+            for (int i = 1; i < 8; i++)
+            {
+                if (temp <= curve[i])
+                {
+                    int t0 = curve[i - 1], t1 = curve[i];
+                    int s0 = curve[i + 7], s1 = curve[i + 8];
+                    if (t1 <= t0) return (byte)Math.Max(s0, s1);
+                    return (byte)(s0 + (s1 - s0) * (temp - t0) / (t1 - t0));
+                }
+            }
+
+            return curve[15];
+        }
+    }
+}

--- a/app/Fan/FanSensorControl.cs
+++ b/app/Fan/FanSensorControl.cs
@@ -136,6 +136,7 @@ namespace GHelper.Fan
 
         public void StartCalibration()
         {
+            FanMaxTempControl.Stop(); // don't let sync overwrite the 100% calibration curves
 
             measuredMax = new int[] { 0, 0, 0 };
             timer.Enabled = true;

--- a/app/Fans.Designer.cs
+++ b/app/Fans.Designer.cs
@@ -42,6 +42,7 @@ namespace GHelper
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Fans));
             panelFans = new Panel();
             checkFanClamp = new RCheckBox();
+            checkFanSync = new RCheckBox();
             labelTip = new Label();
             tableFanCharts = new TableLayoutPanel();
             chartGPU = new RChart();
@@ -237,6 +238,7 @@ namespace GHelper
             panelFans.AutoSize = true;
             panelFans.AutoSizeMode = AutoSizeMode.GrowAndShrink;
             panelFans.Controls.Add(checkFanClamp);
+            panelFans.Controls.Add(checkFanSync);
             panelFans.Controls.Add(labelTip);
             panelFans.Controls.Add(tableFanCharts);
             panelFans.Controls.Add(panelTitleFans);
@@ -263,7 +265,20 @@ namespace GHelper
             checkFanClamp.TabStop = false;
             checkFanClamp.Text = "Clamp to Grid";
             checkFanClamp.UseVisualStyleBackColor = false;
-            // 
+            //
+            // checkFanSync
+            //
+            checkFanSync.AutoSize = true;
+            checkFanSync.Font = new Font("Segoe UI", 8F, FontStyle.Regular, GraphicsUnit.Point, 0);
+            checkFanSync.Location = new Point(215, 80);
+            checkFanSync.Name = "checkFanSync";
+            checkFanSync.Padding = new Padding(8, 1, 2, 1);
+            checkFanSync.Size = new Size(250, 44);
+            checkFanSync.TabIndex = 6;
+            checkFanSync.TabStop = false;
+            checkFanSync.Text = "Sync Fans to Hottest Sensor";
+            checkFanSync.UseVisualStyleBackColor = false;
+            //
             // labelTip
             // 
             labelTip.AutoSize = true;
@@ -2110,6 +2125,7 @@ namespace GHelper
         private RTrackBar trackGPUPower;
         private TableLayoutPanel tableLayoutModes;
         private RCheckBox checkFanClamp;
+        private RCheckBox checkFanSync;
         private Panel panelHysteresis;
         private TableLayoutPanel tableHysteresis;
         private Label labelHysteresisUp;

--- a/app/Fans.cs
+++ b/app/Fans.cs
@@ -77,6 +77,7 @@ namespace GHelper
             buttonCalibrate.Text = Properties.Strings.Calibrate;
 
             checkFanClamp.Text = Properties.Strings.ClampToGrid;
+            checkFanSync.Text = Properties.Strings.FanSyncMaxTemp;
             labelHysteresisUp.Text = Properties.Strings.HysteresisUp;
             labelHysteresisDown.Text = Properties.Strings.HysteresisDown;
             buttonReadLimits.Text = Properties.Strings.ReadLimits;
@@ -174,6 +175,7 @@ namespace GHelper
 
             checkApplyFans.Click += CheckApplyFans_Click;
             checkApplyPower.Click += CheckApplyPower_Click;
+            checkFanSync.Click += CheckFanSync_Click;
 
             trackGPUClockLimit.Minimum = NvidiaGpuControl.MinClockLimit;
             trackGPUClockLimit.Maximum = NvidiaGpuControl.MaxClockLimit;
@@ -973,6 +975,14 @@ namespace GHelper
 
         }
 
+        private void CheckFanSync_Click(object? sender, EventArgs e)
+        {
+            AppConfig.Set("fan_sync_max_temp", checkFanSync.Checked ? 1 : 0);
+
+            FanMaxTempControl.Stop();
+            if (AppConfig.IsApplyFans()) modeControl.AutoFans(); // reapplies curves and starts/stops sync
+        }
+
         public void InitAxis()
         {
             if (this == null || this.Text == "") return;
@@ -1174,6 +1184,7 @@ namespace GHelper
             bool applyFans = AppConfig.IsApplyFans();
 
             checkApplyFans.Checked = applyFans;
+            checkFanSync.Checked = AppConfig.Is("fan_sync_max_temp");
 
             if (autoFans || applyFans)
             {

--- a/app/Mode/ModeControl.cs
+++ b/app/Mode/ModeControl.cs
@@ -1,3 +1,4 @@
+using GHelper.Fan;
 using GHelper.Gpu.NVidia;
 using GHelper.Helpers;
 using GHelper.USB;
@@ -103,6 +104,7 @@ namespace GHelper.Mode
 
         public void ResetPerformanceMode()
         {
+            FanMaxTempControl.Stop();
             ResetRyzen();
 
             Program.acpi.DeviceSet(AsusACPI.PerformanceMode, Modes.GetCurrentBase(), "Mode");
@@ -289,6 +291,9 @@ namespace GHelper.Mode
             {
                 XGM.Reset();
             }
+
+            if (customFans && FanMaxTempControl.IsEnabled) FanMaxTempControl.Start();
+            else FanMaxTempControl.Stop();
 
             SetModeLabel();
 
@@ -608,12 +613,14 @@ namespace GHelper.Mode
         public void ShutdownReset()
         {
             if (!AppConfig.IsShutdownReset()) return;
+            FanMaxTempControl.Stop();
             Program.acpi.DeviceSet(AsusACPI.PerformanceMode,AsusACPI.PerformanceBalanced, "Mode Reset");
         }
 
         public void SleepReset()
         {
             if (!AppConfig.IsSleepReset()) return;
+            FanMaxTempControl.Stop();
             Program.acpi.DeviceSet(AsusACPI.PerformanceMode, Modes.GetCurrentBase(), "Sleep Reset");
         }
 

--- a/app/Properties/Strings.Designer.cs
+++ b/app/Properties/Strings.Designer.cs
@@ -1053,6 +1053,15 @@ namespace GHelper.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Sync Fans to Hottest Sensor.
+        /// </summary>
+        internal static string FanSyncMaxTemp {
+            get {
+                return ResourceManager.GetString("FanSyncMaxTemp", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Fan Profiles.
         /// </summary>
         internal static string FanProfiles {

--- a/app/Properties/Strings.resx
+++ b/app/Properties/Strings.resx
@@ -168,6 +168,9 @@
   <data name="ApplyFanCurve" xml:space="preserve">
     <value>Apply Fan Curve</value>
   </data>
+  <data name="FanSyncMaxTemp" xml:space="preserve">
+    <value>Sync Fans to Hottest Sensor</value>
+  </data>
   <data name="ApplyPowerLimits" xml:space="preserve">
     <value>Apply Power Limits</value>
   </data>


### PR DESCRIPTION
Hi, this adds an opt-in workaround for something that's been bugging me on my M16 (GU604VY) and was asked before in #4411.

With a custom fan curve applied, EC ties each fan strictly to its own sensor. On a shared heatsink this gives two effects:

- GPU fan stays at ~2000 rpm while the CPU sits at 95C, even though both fans cool the same heatpipes
- when the dGPU keeps dozing off and waking up, its fan starts and stops every couple of minutes (EC seems to jump between the GPU sensor and the CPU fallback), which is quite audible in a quiet room

Stock profiles don't do this, fans there follow the hottest component more or less.

What the patch does: a new "Sync Fans to Hottest Sensor" checkbox in Fans + Power. While it's enabled (and only while custom curves are actually applied), a 3s timer takes max(cpu, gpu) temp and re-applies each fan's own curve with the speed points raised to at least what that curve prescribes at that temp. So it's still the usual fan curve endpoint and EC still does all realtime control - fans just can't drop below the "hottest sensor" floor. Curves are only rewritten when the floor actually changes (2C step), so at steady temps there is no extra ACPI traffic at all.

Sync is stopped around calibration, factory reset and sleep/shutdown resets so it never fights them, and it stays inactive when curves are off or were rejected by firmware.

Tested on GU604VY (3 fans incl. mid): CPU load at 95C takes the GPU fan from ~2100 to ~3900 rpm; calibration, mode switching and plug/unplug behave as before with the option off. I understand fan logic is a sensitive area - the feature is fully opt-in and defaults to off.
