### PR TITLE
Fix Strix Halo overlay sensors when ADL PMLog is unavailable

### DIFF
--- a/app/Gpu/AMD/AdlxGpuSensor.cs
+++ b/app/Gpu/AMD/AdlxGpuSensor.cs
@@ -1,0 +1,133 @@
+using System.Runtime.InteropServices;
+
+namespace GHelper.Gpu.AMD;
+
+internal static class AdlxGpuSensor
+{
+    private const ulong AdlxVersion = ((ulong)1 << 48) | ((ulong)5 << 32) | 124;
+    private const int CacheMs = 500;
+    // Function indexes from the backward-compatible ADLX 1.5 C interface vtables.
+    private const int ReleaseIndex = 1;
+    private const int SystemGetGpusIndex = 1;
+    private const int SystemGetPerformanceIndex = 9;
+    private const int ListBeginIndex = 5;
+    private const int GpuListAtIndex = 11;
+    private const int PerformanceGetCurrentGpuIndex = 18;
+    private const int MetricsUsageIndex = 4;
+    private const int MetricsTemperatureIndex = 7;
+    private const int MetricsVramIndex = 12;
+
+    private static readonly object Sync = new();
+    private static bool _initialized;
+    private static bool _initializationAttempted;
+    private static nint _system;
+    private static nint _gpu;
+    private static nint _performance;
+    private static long _lastRead = -CacheMs;
+    private static (int? temp, int? use, int? vramUsedMb) _metrics;
+
+    [DllImport("amdadlx64.dll", CallingConvention = CallingConvention.Cdecl)]
+    private static extern int ADLXInitializeWithIncompatibleDriver(ulong version, out nint system);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int GetInterface(nint self, out nint result);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate uint GetUInt(nint self);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int GetListItem(nint self, uint index, out nint result);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int GetCurrentGpuMetrics(nint self, nint gpu, out nint metrics);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int GetDouble(nint self, out double value);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int GetInt(nint self, out int value);
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int Release(nint self);
+
+    private static T Vtable<T>(nint instance, int index) where T : Delegate
+    {
+        nint vtable = Marshal.ReadIntPtr(instance);
+        return Marshal.GetDelegateForFunctionPointer<T>(Marshal.ReadIntPtr(vtable, index * nint.Size));
+    }
+
+    private static bool Initialize()
+    {
+        if (_initializationAttempted) return _initialized;
+        _initializationAttempted = true;
+
+        nint gpuList = nint.Zero;
+        try
+        {
+            if (ADLXInitializeWithIncompatibleDriver(AdlxVersion, out _system) != 0 || _system == nint.Zero)
+                return false;
+
+            if (Vtable<GetInterface>(_system, SystemGetGpusIndex)(_system, out gpuList) != 0 || gpuList == nint.Zero)
+                return false;
+
+            uint begin = Vtable<GetUInt>(gpuList, ListBeginIndex)(gpuList);
+            if (Vtable<GetListItem>(gpuList, GpuListAtIndex)(gpuList, begin, out _gpu) != 0 || _gpu == nint.Zero)
+                return false;
+
+            if (Vtable<GetInterface>(_system, SystemGetPerformanceIndex)(_system, out _performance) != 0 || _performance == nint.Zero)
+                return false;
+
+            return _initialized = true;
+        }
+        catch
+        {
+            return false;
+        }
+        finally
+        {
+            if (gpuList != nint.Zero)
+                try { Vtable<Release>(gpuList, ReleaseIndex)(gpuList); } catch { }
+        }
+    }
+
+    public static (int? temp, int? use, int? vramUsedMb) GetMetrics()
+    {
+        lock (Sync)
+        {
+            long now = Environment.TickCount64;
+            if (now - _lastRead < CacheMs) return _metrics;
+            if (!Initialize()) return default;
+
+            nint current = nint.Zero;
+            try
+            {
+                if (Vtable<GetCurrentGpuMetrics>(_performance, PerformanceGetCurrentGpuIndex)(_performance, _gpu, out current) != 0 || current == nint.Zero)
+                    return default;
+
+                int? usage = Vtable<GetDouble>(current, MetricsUsageIndex)(current, out double usageValue) == 0
+                    ? Math.Clamp((int)Math.Round(usageValue), 0, 100)
+                    : null;
+                int? temperature = Vtable<GetDouble>(current, MetricsTemperatureIndex)(current, out double temperatureValue) == 0
+                    && temperatureValue is > 0 and < 125
+                    ? (int)Math.Round(temperatureValue)
+                    : null;
+                int? vram = Vtable<GetInt>(current, MetricsVramIndex)(current, out int vramValue) == 0 && vramValue >= 0
+                    ? vramValue
+                    : null;
+
+                _metrics = (temperature, usage, vram);
+                _lastRead = now;
+                return _metrics;
+            }
+            catch
+            {
+                return default;
+            }
+            finally
+            {
+                if (current != nint.Zero)
+                    try { Vtable<Release>(current, ReleaseIndex)(current); } catch { }
+            }
+        }
+    }
+}

--- a/app/Gpu/AMD/AdlxGpuSensor.cs
+++ b/app/Gpu/AMD/AdlxGpuSensor.cs
@@ -15,6 +15,8 @@ internal static class AdlxGpuSensor
     private const int PerformanceGetCurrentGpuIndex = 18;
     private const int MetricsUsageIndex = 4;
     private const int MetricsTemperatureIndex = 7;
+    private const int MetricsPowerIndex = 9;
+    private const int MetricsTotalBoardPowerIndex = 10;
     private const int MetricsVramIndex = 12;
 
     private static readonly object Sync = new();
@@ -24,7 +26,7 @@ internal static class AdlxGpuSensor
     private static nint _gpu;
     private static nint _performance;
     private static long _lastRead = -CacheMs;
-    private static (int? temp, int? use, int? vramUsedMb) _metrics;
+    private static (int? temp, int? use, int? vramUsedMb, float? gpuPower, float? totalBoardPower) _metrics;
 
     [DllImport("amdadlx64.dll", CallingConvention = CallingConvention.Cdecl)]
     private static extern int ADLXInitializeWithIncompatibleDriver(ulong version, out nint system);
@@ -90,7 +92,7 @@ internal static class AdlxGpuSensor
         }
     }
 
-    public static (int? temp, int? use, int? vramUsedMb) GetMetrics()
+    public static (int? temp, int? use, int? vramUsedMb, float? gpuPower, float? totalBoardPower) GetMetrics()
     {
         lock (Sync)
         {
@@ -114,8 +116,16 @@ internal static class AdlxGpuSensor
                 int? vram = Vtable<GetInt>(current, MetricsVramIndex)(current, out int vramValue) == 0 && vramValue >= 0
                     ? vramValue
                     : null;
+                float? gpuPower = Vtable<GetDouble>(current, MetricsPowerIndex)(current, out double gpuPowerValue) == 0
+                    && gpuPowerValue is > 0 and < 1000
+                    ? (float)gpuPowerValue
+                    : null;
+                float? totalBoardPower = Vtable<GetDouble>(current, MetricsTotalBoardPowerIndex)(current, out double totalBoardPowerValue) == 0
+                    && totalBoardPowerValue is > 0 and < 1000
+                    ? (float)totalBoardPowerValue
+                    : null;
 
-                _metrics = (temperature, usage, vram);
+                _metrics = (temperature, usage, vram, gpuPower, totalBoardPower);
                 _lastRead = now;
                 return _metrics;
             }

--- a/app/Gpu/AMD/AmdGpuControl.cs
+++ b/app/Gpu/AMD/AmdGpuControl.cs
@@ -49,7 +49,7 @@ public class AmdGpuControl : IGpuControl
                     if (adapter.Exist == 0 || adapter.Present == 0)
                         return false;
 
-                    if (adapter.VendorID != amdVendorId)
+                    if (Math.Abs(adapter.VendorID) != amdVendorId)
                         return false;
 
                     if (ADL2_Adapter_ASICFamilyType_Get(_adlContextHandle, adapter.AdapterIndex, out ADLAsicFamilyType asicFamilyType, out int asicFamilyTypeValids) != Adl2.ADL_SUCCESS)
@@ -61,7 +61,20 @@ public class AmdGpuControl : IGpuControl
                 });
 
         if (internalDiscreteAdapter.Exist == 0)
-            return null;
+        {
+            if (type != ADLAsicFamilyType.Integrated || !AppConfig.IsAMDiGPU())
+                return null;
+
+            internalDiscreteAdapter = osAdapterInfoData.ADLAdapterInfo
+                .Take(numberOfAdapters)
+                .FirstOrDefault(adapter =>
+                    adapter.Exist != 0 &&
+                    adapter.Present != 0 &&
+                    Math.Abs(adapter.VendorID) == amdVendorId);
+
+            if (internalDiscreteAdapter.Exist == 0)
+                return null;
+        }
 
         return internalDiscreteAdapter;
 
@@ -201,15 +214,22 @@ public class AmdGpuControl : IGpuControl
 
     public (int? temp, int? use, int? gfxPower, int? cpuPower, int? asicPower) GetiGpuSensors()
     {
-        if (!GetPMLogiGpu(out ADLPMLogDataOutput log)) return default;
+        if (!GetPMLogiGpu(out ADLPMLogDataOutput log))
+            return (WindowsGpuSensor.GetTemperature(), WindowsGpuSensor.GetUsage(), null, null, null);
 
-        return (Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_EDGE)
-                ?? Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_GFX)
-                ?? Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_SOC),
-                Sensor(log, ADLSensorType.PMLOG_INFO_ACTIVITY_GFX),
-                Sensor(log, ADLSensorType.PMLOG_GFX_POWER),
-                Sensor(log, ADLSensorType.PMLOG_CPU_POWER),
-                Sensor(log, ADLSensorType.PMLOG_ASIC_POWER));
+        int? edge = Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_EDGE);
+        int? gfx = Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_GFX);
+        int? soc = Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_SOC);
+        int? use = Sensor(log, ADLSensorType.PMLOG_INFO_ACTIVITY_GFX);
+        int? gfxPower = Sensor(log, ADLSensorType.PMLOG_GFX_POWER);
+        int? cpuPower = Sensor(log, ADLSensorType.PMLOG_CPU_POWER);
+        int? asicPower = Sensor(log, ADLSensorType.PMLOG_ASIC_POWER);
+
+        return (edge ?? gfx ?? soc ?? WindowsGpuSensor.GetTemperature(),
+                use ?? WindowsGpuSensor.GetUsage(),
+                gfxPower,
+                cpuPower,
+                asicPower);
     }
 
     public float? GetGpuPower()

--- a/app/Gpu/AMD/AmdGpuControl.cs
+++ b/app/Gpu/AMD/AmdGpuControl.cs
@@ -69,7 +69,7 @@ public class AmdGpuControl : IGpuControl
 
     public AmdGpuControl()
     {
-        if (AppConfig.NoGpu() || !Adl2.Load()) return;
+        if (!Adl2.Load()) return;
 
         try
         {
@@ -93,6 +93,8 @@ public class AmdGpuControl : IGpuControl
     }
 
     public bool IsValid => _isReady && _adlContextHandle != nint.Zero;
+
+    public bool HasIGpu => _adlContextHandle != nint.Zero && _iGPU is not null;
 
     public int? GetCurrentTemperature()
     {
@@ -201,7 +203,9 @@ public class AmdGpuControl : IGpuControl
     {
         if (!GetPMLogiGpu(out ADLPMLogDataOutput log)) return default;
 
-        return (Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_EDGE),
+        return (Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_EDGE)
+                ?? Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_GFX)
+                ?? Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_SOC),
                 Sensor(log, ADLSensorType.PMLOG_INFO_ACTIVITY_GFX),
                 Sensor(log, ADLSensorType.PMLOG_GFX_POWER),
                 Sensor(log, ADLSensorType.PMLOG_CPU_POWER),

--- a/app/Gpu/AMD/AmdGpuControl.cs
+++ b/app/Gpu/AMD/AmdGpuControl.cs
@@ -160,19 +160,19 @@ public class AmdGpuControl : IGpuControl
     public (long usedMb, long totalMb)? GetVramInfo()
     {
         ADLAdapterInfo? adapter = IsValid ? _internalDiscreteAdapter : _iGPU;
-        if (adapter is null) return null;
+        if (adapter is null) return WindowsGpuSensor.GetVramInfo();
         int index = adapter.Value.AdapterIndex;
 
         if (_totalVramMB <= 0)
         {
             if (ADL2_Adapter_MemoryInfo2_Get(_adlContextHandle, index, out ADLMemoryInfo2 mem) != Adl2.ADL_SUCCESS)
-                return null;
+                return WindowsGpuSensor.GetVramInfo();
             _totalVramMB = mem.iMemorySize / (1024 * 1024);
-            if (_totalVramMB <= 0) return null;
+            if (_totalVramMB <= 0) return WindowsGpuSensor.GetVramInfo();
         }
 
         if (ADL2_Adapter_DedicatedVRAMUsage_Get(_adlContextHandle, index, out int usedMB) != Adl2.ADL_SUCCESS)
-            return null;
+            return WindowsGpuSensor.GetVramInfo();
 
         return (usedMB, _totalVramMB);
     }
@@ -215,7 +215,14 @@ public class AmdGpuControl : IGpuControl
     public (int? temp, int? use, int? gfxPower, int? cpuPower, int? asicPower) GetiGpuSensors()
     {
         if (!GetPMLogiGpu(out ADLPMLogDataOutput log))
-            return (WindowsGpuSensor.GetTemperature(), WindowsGpuSensor.GetUsage(), null, null, null);
+        {
+            var adlx = AdlxGpuSensor.GetMetrics();
+            return (adlx.temp ?? WindowsGpuSensor.GetTemperature(),
+                    adlx.use ?? WindowsGpuSensor.GetUsage(),
+                    null,
+                    null,
+                    null);
+        }
 
         int? edge = Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_EDGE);
         int? gfx = Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_GFX);
@@ -224,9 +231,10 @@ public class AmdGpuControl : IGpuControl
         int? gfxPower = Sensor(log, ADLSensorType.PMLOG_GFX_POWER);
         int? cpuPower = Sensor(log, ADLSensorType.PMLOG_CPU_POWER);
         int? asicPower = Sensor(log, ADLSensorType.PMLOG_ASIC_POWER);
+        var adlxFallback = AdlxGpuSensor.GetMetrics();
 
-        return (edge ?? gfx ?? soc ?? WindowsGpuSensor.GetTemperature(),
-                use ?? WindowsGpuSensor.GetUsage(),
+        return (edge ?? gfx ?? soc ?? adlxFallback.temp ?? WindowsGpuSensor.GetTemperature(),
+                use ?? adlxFallback.use ?? WindowsGpuSensor.GetUsage(),
                 gfxPower,
                 cpuPower,
                 asicPower);

--- a/app/Gpu/AMD/AmdGpuControl.cs
+++ b/app/Gpu/AMD/AmdGpuControl.cs
@@ -212,14 +212,14 @@ public class AmdGpuControl : IGpuControl
         return sensor.Supported != 0 ? sensor.Value : null;
     }
 
-    public (int? temp, int? use, int? gfxPower, int? cpuPower, int? asicPower) GetiGpuSensors()
+    public (int? temp, int? use, float? gfxPower, float? cpuPower, float? asicPower) GetiGpuSensors()
     {
         if (!GetPMLogiGpu(out ADLPMLogDataOutput log))
         {
             var adlx = AdlxGpuSensor.GetMetrics();
             return (adlx.temp ?? WindowsGpuSensor.GetTemperature(),
                     adlx.use ?? WindowsGpuSensor.GetUsage(),
-                    null,
+                    adlx.gpuPower ?? adlx.totalBoardPower,
                     null,
                     null);
         }
@@ -228,14 +228,14 @@ public class AmdGpuControl : IGpuControl
         int? gfx = Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_GFX);
         int? soc = Sensor(log, ADLSensorType.PMLOG_TEMPERATURE_SOC);
         int? use = Sensor(log, ADLSensorType.PMLOG_INFO_ACTIVITY_GFX);
-        int? gfxPower = Sensor(log, ADLSensorType.PMLOG_GFX_POWER);
-        int? cpuPower = Sensor(log, ADLSensorType.PMLOG_CPU_POWER);
-        int? asicPower = Sensor(log, ADLSensorType.PMLOG_ASIC_POWER);
+        float? gfxPower = Sensor(log, ADLSensorType.PMLOG_GFX_POWER);
+        float? cpuPower = Sensor(log, ADLSensorType.PMLOG_CPU_POWER);
+        float? asicPower = Sensor(log, ADLSensorType.PMLOG_ASIC_POWER);
         var adlxFallback = AdlxGpuSensor.GetMetrics();
 
         return (edge ?? gfx ?? soc ?? adlxFallback.temp ?? WindowsGpuSensor.GetTemperature(),
                 use ?? adlxFallback.use ?? WindowsGpuSensor.GetUsage(),
-                gfxPower,
+                gfxPower ?? adlxFallback.gpuPower ?? adlxFallback.totalBoardPower,
                 cpuPower,
                 asicPower);
     }

--- a/app/Gpu/AMD/WindowsGpuSensor.cs
+++ b/app/Gpu/AMD/WindowsGpuSensor.cs
@@ -1,0 +1,200 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace GHelper.Gpu.AMD;
+
+internal static class WindowsGpuSensor
+{
+    private const int AdapterPerfData = 62;
+    private const int CounterRefreshMs = 5000;
+
+    private static readonly object CounterLock = new();
+    private static readonly Dictionary<string, PerformanceCounter> UsageCounters = new(StringComparer.OrdinalIgnoreCase);
+    private static string? _luidToken;
+    private static long _lastCounterRefresh = -CounterRefreshMs;
+    private static long _temperatureTick = -500;
+    private static int? _temperature;
+    private static long _usageTick = -500;
+    private static int? _usage;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Luid
+    {
+        public uint LowPart;
+        public int HighPart;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct OpenAdapterFromGdiDisplayName
+    {
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        public string DeviceName;
+        public uint AdapterHandle;
+        public Luid AdapterLuid;
+        public uint VidPnSourceId;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct QueryAdapterInfo
+    {
+        public uint AdapterHandle;
+        public int Type;
+        public nint PrivateDriverData;
+        public uint PrivateDriverDataSize;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct AdapterPerformanceData
+    {
+        public uint PhysicalAdapterIndex;
+        public ulong MemoryFrequency;
+        public ulong MaxMemoryFrequency;
+        public ulong MaxMemoryFrequencyOc;
+        public ulong MemoryBandwidth;
+        public ulong PcieBandwidth;
+        public uint FanRpm;
+        public uint Power;
+        public uint Temperature;
+        public byte PowerStateOverride;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct CloseAdapter
+    {
+        public uint AdapterHandle;
+    }
+
+    [DllImport("gdi32.dll", CharSet = CharSet.Unicode)]
+    private static extern int D3DKMTOpenAdapterFromGdiDisplayName(ref OpenAdapterFromGdiDisplayName data);
+
+    [DllImport("gdi32.dll")]
+    private static extern int D3DKMTQueryAdapterInfo(ref QueryAdapterInfo data);
+
+    [DllImport("gdi32.dll")]
+    private static extern int D3DKMTCloseAdapter(ref CloseAdapter data);
+
+    private static bool TryQueryPerformanceData(out AdapterPerformanceData performanceData, out Luid adapterLuid)
+    {
+        performanceData = default;
+        adapterLuid = default;
+
+        string? deviceName = Screen.PrimaryScreen?.DeviceName;
+        if (string.IsNullOrEmpty(deviceName)) return false;
+
+        OpenAdapterFromGdiDisplayName open = new() { DeviceName = deviceName };
+        if (D3DKMTOpenAdapterFromGdiDisplayName(ref open) != 0 || open.AdapterHandle == 0) return false;
+
+        nint buffer = Marshal.AllocHGlobal(Marshal.SizeOf<AdapterPerformanceData>());
+        try
+        {
+            Marshal.StructureToPtr(performanceData, buffer, false);
+            QueryAdapterInfo query = new()
+            {
+                AdapterHandle = open.AdapterHandle,
+                Type = AdapterPerfData,
+                PrivateDriverData = buffer,
+                PrivateDriverDataSize = (uint)Marshal.SizeOf<AdapterPerformanceData>()
+            };
+
+            if (D3DKMTQueryAdapterInfo(ref query) != 0) return false;
+            performanceData = Marshal.PtrToStructure<AdapterPerformanceData>(buffer);
+            adapterLuid = open.AdapterLuid;
+            return true;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+            CloseAdapter close = new() { AdapterHandle = open.AdapterHandle };
+            D3DKMTCloseAdapter(ref close);
+        }
+    }
+
+    public static int? GetTemperature()
+    {
+        try
+        {
+            long now = Environment.TickCount64;
+            if (now - _temperatureTick < 500) return _temperature;
+
+            if (!TryQueryPerformanceData(out AdapterPerformanceData data, out _)) return null;
+            _temperature = data.Temperature is > 0 and < 1250
+                ? (int)Math.Round(data.Temperature / 10.0)
+                : null;
+            _temperatureTick = now;
+            return _temperature;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public static int? GetUsage()
+    {
+        try
+        {
+            lock (CounterLock)
+            {
+                long now = Environment.TickCount64;
+                if (now - _usageTick < 500) return _usage;
+
+                if (_luidToken is null)
+                {
+                    if (!TryQueryPerformanceData(out _, out Luid luid)) return null;
+                    _luidToken = $"luid_0x{(uint)luid.HighPart:x8}_0x{luid.LowPart:x8}";
+                }
+
+                RefreshUsageCounters();
+                Dictionary<string, float> engineUsage = new(StringComparer.OrdinalIgnoreCase);
+
+                foreach ((string instance, PerformanceCounter counter) in UsageCounters)
+                {
+                    int engineStart = instance.IndexOf("_phys_", StringComparison.OrdinalIgnoreCase);
+                    int engineEnd = instance.IndexOf("_engtype_", StringComparison.OrdinalIgnoreCase);
+                    if (engineStart < 0 || engineEnd <= engineStart) continue;
+
+                    float value;
+                    try { value = counter.NextValue(); }
+                    catch { continue; }
+
+                    string engine = instance[engineStart..engineEnd];
+                    engineUsage[engine] = engineUsage.GetValueOrDefault(engine) + value;
+                }
+
+                _usage = engineUsage.Count == 0
+                    ? 0
+                    : Math.Clamp((int)Math.Round(engineUsage.Values.Max()), 0, 100);
+                _usageTick = now;
+                return _usage;
+            }
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void RefreshUsageCounters()
+    {
+        long now = Environment.TickCount64;
+        if (now - _lastCounterRefresh < CounterRefreshMs) return;
+        _lastCounterRefresh = now;
+
+        PerformanceCounterCategory category = new("GPU Engine");
+        HashSet<string> activeInstances = category.GetInstanceNames()
+            .Where(instance => instance.Contains(_luidToken!, StringComparison.OrdinalIgnoreCase))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (string instance in activeInstances)
+        {
+            if (!UsageCounters.ContainsKey(instance))
+                UsageCounters[instance] = new PerformanceCounter("GPU Engine", "Utilization Percentage", instance, true);
+        }
+
+        foreach (string instance in UsageCounters.Keys.Except(activeInstances, StringComparer.OrdinalIgnoreCase).ToArray())
+        {
+            UsageCounters[instance].Dispose();
+            UsageCounters.Remove(instance);
+        }
+    }
+}

--- a/app/Gpu/AMD/WindowsGpuSensor.cs
+++ b/app/Gpu/AMD/WindowsGpuSensor.cs
@@ -9,6 +9,7 @@ internal static class WindowsGpuSensor
     private const int CounterRefreshMs = 5000;
 
     private static readonly object CounterLock = new();
+    private static readonly object MemoryLock = new();
     private static readonly Dictionary<string, PerformanceCounter> UsageCounters = new(StringComparer.OrdinalIgnoreCase);
     private static string? _luidToken;
     private static long _lastCounterRefresh = -CounterRefreshMs;
@@ -16,6 +17,8 @@ internal static class WindowsGpuSensor
     private static int? _temperature;
     private static long _usageTick = -500;
     private static int? _usage;
+    private static PerformanceCounter? _dedicatedMemoryCounter;
+    private static long _vramBudgetMb;
 
     [StructLayout(LayoutKind.Sequential)]
     private struct Luid
@@ -64,6 +67,19 @@ internal static class WindowsGpuSensor
         public uint AdapterHandle;
     }
 
+    [StructLayout(LayoutKind.Sequential)]
+    private struct QueryVideoMemoryInfo
+    {
+        public nint ProcessHandle;
+        public uint AdapterHandle;
+        public int MemorySegmentGroup;
+        public ulong Budget;
+        public ulong CurrentUsage;
+        public ulong CurrentReservation;
+        public ulong AvailableForReservation;
+        public uint PhysicalAdapterIndex;
+    }
+
     [DllImport("gdi32.dll", CharSet = CharSet.Unicode)]
     private static extern int D3DKMTOpenAdapterFromGdiDisplayName(ref OpenAdapterFromGdiDisplayName data);
 
@@ -72,6 +88,12 @@ internal static class WindowsGpuSensor
 
     [DllImport("gdi32.dll")]
     private static extern int D3DKMTCloseAdapter(ref CloseAdapter data);
+
+    [DllImport("gdi32.dll")]
+    private static extern int D3DKMTQueryVideoMemoryInfo(ref QueryVideoMemoryInfo data);
+
+    private static string LuidToken(Luid luid)
+        => $"luid_0x{(uint)luid.HighPart:x8}_0x{luid.LowPart:x8}";
 
     private static bool TryQueryPerformanceData(out AdapterPerformanceData performanceData, out Luid adapterLuid)
     {
@@ -141,7 +163,7 @@ internal static class WindowsGpuSensor
                 if (_luidToken is null)
                 {
                     if (!TryQueryPerformanceData(out _, out Luid luid)) return null;
-                    _luidToken = $"luid_0x{(uint)luid.HighPart:x8}_0x{luid.LowPart:x8}";
+                    _luidToken = LuidToken(luid);
                 }
 
                 RefreshUsageCounters();
@@ -170,6 +192,63 @@ internal static class WindowsGpuSensor
         }
         catch
         {
+            return null;
+        }
+    }
+
+    public static (long usedMb, long totalMb)? GetVramInfo()
+    {
+        try
+        {
+            lock (MemoryLock)
+            {
+                if (_vramBudgetMb <= 0 || _luidToken is null)
+                {
+                    string? deviceName = Screen.PrimaryScreen?.DeviceName;
+                    if (string.IsNullOrEmpty(deviceName)) return null;
+
+                    OpenAdapterFromGdiDisplayName open = new() { DeviceName = deviceName };
+                    if (D3DKMTOpenAdapterFromGdiDisplayName(ref open) != 0 || open.AdapterHandle == 0) return null;
+
+                    try
+                    {
+                        QueryVideoMemoryInfo memory = new()
+                        {
+                            AdapterHandle = open.AdapterHandle,
+                            MemorySegmentGroup = 0,
+                            PhysicalAdapterIndex = 0
+                        };
+                        if (D3DKMTQueryVideoMemoryInfo(ref memory) != 0 || memory.Budget == 0) return null;
+
+                        _vramBudgetMb = (long)(memory.Budget / (1024 * 1024));
+                        _luidToken = LuidToken(open.AdapterLuid);
+                    }
+                    finally
+                    {
+                        CloseAdapter close = new() { AdapterHandle = open.AdapterHandle };
+                        D3DKMTCloseAdapter(ref close);
+                    }
+                }
+
+                int? adlxUsedMb = AdlxGpuSensor.GetMetrics().vramUsedMb;
+                if (adlxUsedMb is null && _dedicatedMemoryCounter is null)
+                {
+                    PerformanceCounterCategory category = new("GPU Adapter Memory");
+                    string? instance = category.GetInstanceNames()
+                        .FirstOrDefault(name => name.Contains(_luidToken, StringComparison.OrdinalIgnoreCase));
+                    if (instance is null) return null;
+
+                    _dedicatedMemoryCounter = new PerformanceCounter("GPU Adapter Memory", "Dedicated Usage", instance, true);
+                }
+
+                long usedMb = adlxUsedMb ?? (long)Math.Round(_dedicatedMemoryCounter!.NextValue() / (1024 * 1024));
+                return (usedMb, _vramBudgetMb);
+            }
+        }
+        catch
+        {
+            _dedicatedMemoryCounter?.Dispose();
+            _dedicatedMemoryCounter = null;
             return null;
         }
     }

--- a/app/HardwareControl.cs
+++ b/app/HardwareControl.cs
@@ -527,7 +527,7 @@ public static class HardwareControl
     private static int _cpuPowerNullTicks;
     private static int _cpuPowerReadErrors;
     private const int CpuPowerMaxReadErrors = 3;
-    private static readonly string[] _powerCounterInstances = { "Apu Power", "RAPL_Package0_PKG", "CPU Power", "Socket Power", "Current Socket Power" };
+    private static readonly string[] _powerCounterInstances = { "RAPL_Package0_PKG", "CPU Power", "Apu Power", "Socket Power", "Current Socket Power" };
 
     public static void InitCPUPowerAsync()
     {
@@ -536,25 +536,6 @@ public static class HardwareControl
 
         Task.Run(() =>
         {
-            if (isAMDiGPU && _coreCounters is null)
-                try
-                {
-                    var names = new PerformanceCounterCategory("Energy Meter").GetInstanceNames();
-                    var cores = new List<PerformanceCounter>();
-                    foreach (var name in names.Where(n => n.EndsWith("_CORE")))
-                    {
-                        var counter = new PerformanceCounter("Energy Meter", "Power", name, true);
-                        counter.NextValue();
-                        cores.Add(counter);
-                    }
-                    if (cores.Count > 0)
-                    {
-                        _coreCounters = cores;
-                        Logger.WriteLine($"CPU Power source: {cores.Count} RAPL cores");
-                    }
-                }
-                catch { }
-
             // Try cached instance name first — skips the PerformanceCounterCategory
             // enumeration which costs ~1–2 s on a cold perflib cache.
             var cached = AppConfig.GetString("cpu_power_counter");
@@ -599,25 +580,6 @@ public static class HardwareControl
                 _cpuPowerCounterFailed = true;
             }
         });
-    }
-
-    private static List<PerformanceCounter>? _coreCounters;
-
-    private static float? GetCoresPower()
-    {
-        var counters = _coreCounters;
-        if (counters is null) return null;
-        try
-        {
-            float mW = 0;
-            foreach (var counter in counters) mW += counter.NextValue();
-            return mW > 0 ? mW / 1000f : null;
-        }
-        catch
-        {
-            _coreCounters = null;
-            return null;
-        }
     }
 
     public static float? GetCPUPower()
@@ -873,13 +835,15 @@ public static class HardwareControl
 
             if (isAMDiGPU && GpuControl is null)
             {
-                float? cores = GetCoresPower();
-                if (cores > 0 && newCpu > cores)
+                var adlx = AdlxGpuSensor.GetMetrics();
+                iGpuPower = adlx.gpuPower ?? adlx.totalBoardPower;
+
+                // On current AMD APUs, RAPL_Package0_PKG is already the CPU package
+                // reading. Splitting it into a sum of core counters plus a derived GPU
+                // remainder produces neither AMD's CPU nor GPU metric. Use ADLX for the
+                // GPU and keep the package counter intact for the CPU.
+                if (iGpuPower is null)
                 {
-                    iGpuPower = newCpu - cores;
-                    newCpu = cores;
-                }
-                else
                     try
                     {
                         var (_, _, gfxPower, corePower, asicPower) = AmdApu().GetiGpuSensors();
@@ -888,6 +852,7 @@ public static class HardwareControl
                         else if (asicPower > gfxPower) newCpu = asicPower - gfxPower;
                     }
                     catch { }
+                }
             }
 
             if (newCpu > 0)

--- a/app/HardwareControl.cs
+++ b/app/HardwareControl.cs
@@ -58,7 +58,8 @@ public static class HardwareControl
 
     static bool isPZ13 = AppConfig.IsPZ13();
     static bool isAlly = AppConfig.IsAlly();
-    static bool isAMDiGPU = AppConfig.IsAMDiGPU();
+    static bool isAMDiGPU => PawnIO.CpuInfo.IsAMD && AmdApu().HasIGpu;
+    public static bool IsIGpu => isAMDiGPU && GpuControl is null;
 
     static bool _chargeWatt = AppConfig.Is("charge_watt");
 

--- a/app/HardwareControl.cs
+++ b/app/HardwareControl.cs
@@ -536,6 +536,25 @@ public static class HardwareControl
 
         Task.Run(() =>
         {
+            if (isAMDiGPU && _coreCounters is null)
+                try
+                {
+                    var names = new PerformanceCounterCategory("Energy Meter").GetInstanceNames();
+                    var cores = new List<PerformanceCounter>();
+                    foreach (var name in names.Where(n => n.EndsWith("_CORE")))
+                    {
+                        var counter = new PerformanceCounter("Energy Meter", "Power", name, true);
+                        counter.NextValue();
+                        cores.Add(counter);
+                    }
+                    if (cores.Count > 0)
+                    {
+                        _coreCounters = cores;
+                        Logger.WriteLine($"CPU Power source: {cores.Count} RAPL cores");
+                    }
+                }
+                catch { }
+
             // Try cached instance name first — skips the PerformanceCounterCategory
             // enumeration which costs ~1–2 s on a cold perflib cache.
             var cached = AppConfig.GetString("cpu_power_counter");
@@ -580,6 +599,25 @@ public static class HardwareControl
                 _cpuPowerCounterFailed = true;
             }
         });
+    }
+
+    private static List<PerformanceCounter>? _coreCounters;
+
+    private static float? GetCoresPower()
+    {
+        var counters = _coreCounters;
+        if (counters is null) return null;
+        try
+        {
+            float mW = 0;
+            foreach (var counter in counters) mW += counter.NextValue();
+            return mW > 0 ? mW / 1000f : null;
+        }
+        catch
+        {
+            _coreCounters = null;
+            return null;
+        }
     }
 
     public static float? GetCPUPower()
@@ -837,19 +875,24 @@ public static class HardwareControl
             {
                 var adlx = AdlxGpuSensor.GetMetrics();
                 iGpuPower = adlx.gpuPower ?? adlx.totalBoardPower;
+                float? coresPower = GetCoresPower();
+                newCpu = coresPower > 0 ? coresPower : null;
 
-                // On current AMD APUs, RAPL_Package0_PKG is already the CPU package
-                // reading. Splitting it into a sum of core counters plus a derived GPU
-                // remainder produces neither AMD's CPU nor GPU metric. Use ADLX for the
-                // GPU and keep the package counter intact for the CPU.
-                if (iGpuPower is null)
+                // On current AMD APUs, RAPL_Package0_PKG includes shared graphics/SoC
+                // domains. AMD Software's CPU metric matches the sum of the per-core
+                // RAPL counters, while its GPU metric comes directly from ADLX. Read
+                // both independently instead of deriving one by subtracting the other.
+                if (iGpuPower is null || newCpu is null)
                 {
                     try
                     {
                         var (_, _, gfxPower, corePower, asicPower) = AmdApu().GetiGpuSensors();
-                        if (gfxPower > 0) iGpuPower = gfxPower;
-                        if (corePower > 0) newCpu = corePower;
-                        else if (asicPower > gfxPower) newCpu = asicPower - gfxPower;
+                        if (iGpuPower is null && gfxPower > 0) iGpuPower = gfxPower;
+                        if (newCpu is null)
+                        {
+                            if (corePower > 0) newCpu = corePower;
+                            else if (asicPower > gfxPower) newCpu = asicPower - gfxPower;
+                        }
                     }
                     catch { }
                 }

--- a/app/Overlay/EtwFpsMonitor.cs
+++ b/app/Overlay/EtwFpsMonitor.cs
@@ -33,9 +33,14 @@ namespace GHelper.Overlay
         private const ushort DXGKRNL_TASK_FLIP = 14;
         private const byte DXGKRNL_OPCODE_START = 1;
 
+        // DxgKrnl Present_Info — the only per-frame event for blit-model windowed presents
+        // (AMD Vulkan/OpenGL), which emit neither DXGI event 42 nor a Flip.
+        private const ushort EVENT_DXGKRNL_PRESENT_INFO = 184;
+
         // Keyword mask for the DxgKrnl provider — scopes to flip/present-related events only
         // so we don't receive every kernel GPU event system-wide (which would be very high volume).
-        private const ulong DXGKRNL_KEYWORD_PRESENT = 0x0000040000000000UL;
+        // 0x8000000 carries Present_Info (184), 0x40000000000 the flips.
+        private const ulong DXGKRNL_KEYWORD_PRESENT = 0x0000040008000000UL;
 
         // Kernel-side filter descriptors — applied once on first known foreground PID so we
         // stop receiving events from every other GPU process system-wide.
@@ -230,6 +235,7 @@ namespace GHelper.Overlay
         // Some DX12 games emit both — this flag suppresses DxgKrnl once DXGI is confirmed active
         // for the current PID. Resets on every PID switch.
         private bool _dxgiActiveForCurrentPid = false;
+        private bool _flipActiveForCurrentPid = false;
 
         // Rolling-window FPS using EventHeader.TimeStamp (raw QPC ticks at Present call time).
         // Critical: ETW batches events and delivers them all at once, so Stopwatch.GetTimestamp()
@@ -461,15 +467,30 @@ namespace GHelper.Overlay
             // DxgKrnl Flip_Start — DX12 flip-model and Vulkan games (e.g. KCD2) that call
             // D3DKMTPresent via the kernel without surfacing a DXGI event 42.
             // Task=14 (Flip), Opcode=1 (Start) fires once per submitted flip-model frame.
-            bool isDxgKrnlPresent = record.EventHeader.ProviderId == DxgKrnlProviderId
-                                 && record.EventHeader.Task == DXGKRNL_TASK_FLIP
-                                 && record.EventHeader.Opcode == DXGKRNL_OPCODE_START;
+            bool isDxgKrnlFlip = record.EventHeader.ProviderId == DxgKrnlProviderId
+                              && record.EventHeader.Task == DXGKRNL_TASK_FLIP
+                              && record.EventHeader.Opcode == DXGKRNL_OPCODE_START;
 
-            if (!isDxgiPresent && !isDxgKrnlPresent) return;
+            bool isDxgKrnlBlitPresent = record.EventHeader.ProviderId == DxgKrnlProviderId
+                                     && record.EventHeader.Id == EVENT_DXGKRNL_PRESENT_INFO;
+
+            if (!isDxgiPresent && !isDxgKrnlFlip && !isDxgKrnlBlitPresent) return;
 
             int targetPid = _targetPid;
             if (targetPid == 0) return;                                    // no foreground target yet
             if ((int)record.EventHeader.ProcessId != targetPid) return;    // wrong process
+
+            // PID changed — reset rolling window so stale timestamps don't pollute new readings.
+            // Runs before the preference latches so a stale one can't mute the new process.
+            if (targetPid != _lastTargetPid)
+            {
+                _lastTargetPid = targetPid;
+                _frameHead = 0;
+                _framesFilled = 0;
+                _dxgiActiveForCurrentPid = false;
+                _flipActiveForCurrentPid = false;
+                return;
+            }
 
             // DXGI_PRESENT_TEST presents probe swapchain state without displaying a frame.
             // S.T.A.L.K.E.R. Anomaly's X-Ray engine fires one between every real Present,
@@ -488,15 +509,11 @@ namespace GHelper.Overlay
             else if (_dxgiActiveForCurrentPid)
                 return;
 
-            // PID changed — reset rolling window so stale timestamps don't pollute new readings
-            if (targetPid != _lastTargetPid)
-            {
-                _lastTargetPid = targetPid;
-                _frameHead = 0;
-                _framesFilled = 0;
-                _dxgiActiveForCurrentPid = false;
+            // Same one tier down: prefer Flip over blit Present_Info (flip games emit both).
+            if (isDxgKrnlFlip)
+                _flipActiveForCurrentPid = true;
+            else if (isDxgKrnlBlitPresent && _flipActiveForCurrentPid)
                 return;
-            }
 
             // EventHeader.TimeStamp = kernel QPC tick at the moment Present() was called.
             // This is NOT affected by ETW delivery batching, giving accurate inter-frame timing.

--- a/app/Overlay/EtwFpsMonitor.cs
+++ b/app/Overlay/EtwFpsMonitor.cs
@@ -5,7 +5,6 @@ namespace GHelper.Overlay
 {
     public sealed class EtwFpsMonitor : IDisposable
     {
-        // ── ETW Constants ────────────────────────────────────────────────────────
         private const uint ERROR_SUCCESS = 0;
         private const uint EVENT_CONTROL_CODE_ENABLE_PROVIDER = 1;
         private const uint EVENT_CONTROL_CODE_DISABLE_PROVIDER = 0;
@@ -32,8 +31,6 @@ namespace GHelper.Overlay
         private const uint ENABLE_TRACE_PARAMETERS_VERSION_2 = 2;
 
         private const string SessionName = "FpsMonitorSession";
-
-        // ── P/Invoke Structures ──────────────────────────────────────────────────
 
         [StructLayout(LayoutKind.Sequential)]
         private struct WNODE_HEADER
@@ -74,16 +71,11 @@ namespace GHelper.Overlay
             public string LogFileName;
         }
 
+        // Truncated to EventHeader — the callback reads the record in place and needs nothing past it
         [StructLayout(LayoutKind.Sequential)]
         private struct EVENT_RECORD
         {
             public EVENT_HEADER EventHeader;
-            public ETW_BUFFER_CONTEXT BufferContext;
-            public ushort ExtendedDataCount;
-            public ushort UserDataLength;
-            public IntPtr ExtendedData;
-            public IntPtr UserData;
-            public IntPtr UserContext;
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -109,16 +101,7 @@ namespace GHelper.Overlay
             public Guid ActivityId;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
-        private struct ETW_BUFFER_CONTEXT
-        {
-            public byte ProcessorNumber;
-            public byte Alignment;
-            public ushort LoggerId;
-        }
-
-        // Ptr is declared ULONGLONG in Windows headers (not a real pointer) so it's 8 bytes
-        // on every architecture — using ulong keeps the layout right regardless of bitness.
+        // Ptr is ULONGLONG in Windows headers (8 bytes on every architecture), not a pointer
         [StructLayout(LayoutKind.Sequential)]
         private struct EVENT_FILTER_DESCRIPTOR
         {
@@ -138,28 +121,7 @@ namespace GHelper.Overlay
             public uint   FilterDescCount;
         }
 
-        // ── EVENT_TRACE_LOGFILE — explicit layout with correct 64-bit offsets ───
-        //
-        // Native field map (x64):
-        //   offset 0   : LPWSTR LogFileName
-        //   offset 8   : LPWSTR LoggerName
-        //   offset 16  : LONGLONG CurrentTime
-        //   offset 24  : ULONG BuffersRead
-        //   offset 28  : ULONG ProcessTraceMode  ← we set this
-        //   offset 32  : EVENT_TRACE CurrentEvent (88 bytes)
-        //   offset 120 : TRACE_LOGFILE_HEADER LogfileHeader (280 bytes)
-        //   offset 400 : PTR BufferCallback
-        //   offset 408 : ULONG BufferSize
-        //   offset 412 : ULONG Filled
-        //   offset 416 : ULONG EventsLost
-        //   offset 420 : (4-byte pad)
-        //   offset 424 : PTR EventRecordCallback  ← we set this
-        //   offset 432 : ULONG IsKernelTrace
-        //   offset 436 : (4-byte pad)
-        //   offset 440 : PVOID Context
-        //   total 448 bytes
-        //
-        // We use IntPtr for pointer fields to avoid marshaler interference.
+        // Explicit layout at native x64 offsets — raw IntPtrs keep the marshaler out
         [StructLayout(LayoutKind.Explicit, Size = 448)]
         private struct EVENT_TRACE_LOGFILE
         {
@@ -173,7 +135,6 @@ namespace GHelper.Overlay
         // Callback delegate — must match PEVENT_RECORD_CALLBACK signature exactly
         private delegate void EventRecordCallback([In] ref EVENT_RECORD eventRecord);
 
-        // ── P/Invoke Functions ───────────────────────────────────────────────────
         [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
         private static extern uint StartTrace(out long sessionHandle,
             string sessionName, ref EVENT_TRACE_PROPERTIES properties);
@@ -203,7 +164,6 @@ namespace GHelper.Overlay
         [DllImport("advapi32.dll")]
         private static extern uint CloseTrace(long traceHandle);
 
-        // ── State ────────────────────────────────────────────────────────────────
         private long _sessionHandle;
         private long _traceHandle;
 
@@ -213,11 +173,8 @@ namespace GHelper.Overlay
         private long _lastFlushTick;             // ≥1 s flush floor
         private volatile int _targetPid = -1;
 
-        // Rolling-window FPS using EventHeader.TimeStamp (raw QPC ticks at Present call time).
-        // Critical: ETW batches events and delivers them all at once, so Stopwatch.GetTimestamp()
-        // at callback time is nearly identical for every frame in the batch — causing fps = N/~0.
-        // EventHeader.TimeStamp is stamped by the kernel when Present() actually fired, so it
-        // correctly reflects the real inter-frame spacing regardless of delivery batching.
+        // Rolling window of EventHeader.TimeStamp (kernel QPC at Present time) — ETW delivers
+        // events in batches, so callback-time timestamps would collapse to fps = N/~0.
         private const int RollingWindowSize = 360; // frames — holds a full 1 s window up to 360 fps
         private readonly long[] _frameTimes = new long[RollingWindowSize];
         private volatile int _frameHead = 0;    // next write slot — read by overlay tick thread
@@ -225,8 +182,7 @@ namespace GHelper.Overlay
 
         private EventRecordCallback? _callbackRef; // keep delegate alive — prevents GC collection
 
-        /// Set to the foreground process PID to filter events.
-        /// 0 = no target, no events counted (overlay shows "--").
+        /// Foreground PID to count; 0 = no target, provider paused, overlay shows "--"
         public int TargetPid
         {
             get => _targetPid;
@@ -295,20 +251,13 @@ namespace GHelper.Overlay
             }
         }
 
-        // ── Public API ───────────────────────────────────────────────────────────
-
-        /// <summary>
-        /// Starts the ETW session. Blocks the calling thread — always run via Task.Run.
-        /// Requires Administrator privileges.
-        /// </summary>
+        /// Starts the ETW session. Blocks the calling thread — always run via Task.Run. Requires admin.
         public void Start(int targetPid = -1)
         {
             _targetPid = targetPid;
 
-            // Kill any stale session left by a previous unclean exit. Otherwise StartTrace
-            // returns ERROR_ALREADY_EXISTS without populating sessionHandle, EnableTraceEx2
-            // silently fails against the invalid handle, and FPS stays at "--" until the
-            // user hides/shows the overlay (Stop() finds the orphaned session by name).
+            // Kill any stale session from an unclean exit — else StartTrace returns
+            // ERROR_ALREADY_EXISTS with no usable handle and FPS stays at "--"
             var stopProps = BuildSessionProperties();
             StopTrace(0, SessionName, ref stopProps);
 
@@ -323,15 +272,10 @@ namespace GHelper.Overlay
             if (hr != ERROR_SUCCESS)
                 throw new InvalidOperationException($"StartTrace failed: 0x{hr:X}");
 
-            // 2. Subscribe to the DxgKrnl provider — Present_Info fires once per frame
-            //    for every graphics API.
+            // 2. Subscribe to DxgKrnl — Present_Info fires once per frame for every graphics API
             EnableProvider();
 
-            // 3. Open the real-time consumer using explicit-layout struct.
-            //    LoggerName and EventRecordCallback are marshaled as raw IntPtrs to
-            //    guarantee correct placement at the native 64-bit offsets.
-            //    PROCESS_TRACE_MODE_RAW_TIMESTAMP makes EventHeader.TimeStamp a raw QPC
-            //    value (same units as Stopwatch.Frequency) instead of low-res system time.
+            // 3. Open the real-time consumer. RAW_TIMESTAMP = EventHeader.TimeStamp in QPC ticks.
             _callbackRef = OnEventRecord;
             IntPtr loggerNamePtr = Marshal.StringToHGlobalUni(SessionName);
             try
@@ -385,8 +329,6 @@ namespace GHelper.Overlay
 
         public void Dispose() => Stop();
 
-        // ── Internal ─────────────────────────────────────────────────────────────
-
         private void OnEventRecord(ref EVENT_RECORD record)
         {
             if (record.EventHeader.ProviderId != DxgKrnlProviderId
@@ -395,8 +337,6 @@ namespace GHelper.Overlay
             int targetPid = _targetPid;
             if (targetPid <= 0 || (int)record.EventHeader.ProcessId != targetPid) return;
 
-            // EventHeader.TimeStamp = kernel QPC tick at the moment Present() was called.
-            // This is NOT affected by ETW delivery batching, giving accurate inter-frame timing.
             _frameTimes[_frameHead] = record.EventHeader.TimeStamp;
             _frameHead = (_frameHead + 1) % RollingWindowSize;
             if (_framesFilled < RollingWindowSize) _framesFilled++;

--- a/app/Overlay/EtwFpsMonitor.cs
+++ b/app/Overlay/EtwFpsMonitor.cs
@@ -15,32 +15,16 @@ namespace GHelper.Overlay
         private const uint PROCESS_TRACE_MODE_EVENT_RECORD = 0x10000000;
         private const uint PROCESS_TRACE_MODE_RAW_TIMESTAMP = 0x00001000; // EventHeader.TimeStamp = raw QPC ticks
         private const uint WNODE_FLAG_TRACED_GUID = 0x00020000;
-        private const int EVENT_DXGI_PRESENT_START = 42;
 
-        // Microsoft-Windows-DXGI provider — DX11 + some DX12 games (user-mode swapchain path)
-        private static readonly Guid DxgiProviderId =
-            new("CA11C036-0102-4A2D-A6AD-F03CFED5D3C9");
-
-        // Microsoft-Windows-DxgKrnl provider — DX12 flip-model + Vulkan (kernel present path)
-        // Games like Kingdom Come: Deliverance 2 use DX12/Vulkan and bypass the DXGI user-mode
-        // present path, so they never fire DXGI event 42. DxgKrnl covers this case.
+        // Microsoft-Windows-DxgKrnl provider — kernel present path shared by every graphics API
         private static readonly Guid DxgKrnlProviderId =
             new("802EC45A-1E99-4B83-9920-87C98277BA9D");
 
-        // DxgKrnl_Flip_Start: Task=14 (0xE), Opcode=1
-        // Fires once per frame when a flip-model present is submitted to the hardware.
-        // Covers both DX12 (IDXGISwapChain flip model) and Vulkan (vkQueuePresentKHR).
-        private const ushort DXGKRNL_TASK_FLIP = 14;
-        private const byte DXGKRNL_OPCODE_START = 1;
-
-        // DxgKrnl Present_Info — the only per-frame event for blit-model windowed presents
-        // (AMD Vulkan/OpenGL), which emit neither DXGI event 42 nor a Flip.
+        // DxgKrnl Present_Info — kernel D3DKMTPresent, once per frame for every present path
         private const ushort EVENT_DXGKRNL_PRESENT_INFO = 184;
 
-        // Keyword mask for the DxgKrnl provider — scopes to flip/present-related events only
-        // so we don't receive every kernel GPU event system-wide (which would be very high volume).
-        // 0x8000000 carries Present_Info (184), 0x40000000000 the flips.
-        private const ulong DXGKRNL_KEYWORD_PRESENT = 0x0000040008000000UL;
+        // Keyword bit carrying Present_Info — keeps high-volume kernel GPU events out
+        private const ulong DXGKRNL_KEYWORD_PRESENT = 0x0000000008000000UL;
 
         // Kernel-side filter descriptors — applied once on first known foreground PID so we
         // stop receiving events from every other GPU process system-wide.
@@ -114,7 +98,7 @@ namespace GHelper.Overlay
             public uint ProcessId;
             public long TimeStamp; // raw QPC ticks when PROCESS_TRACE_MODE_RAW_TIMESTAMP is set
             public Guid ProviderId;
-            public ushort Id; // 42 = PresentStart (DXGI)
+            public ushort Id;
             public byte Version;
             public byte Channel;
             public byte Level;
@@ -231,12 +215,6 @@ namespace GHelper.Overlay
         private volatile int _targetPid = -1;
         private int _lastTargetPid;       // detects PID switches so the window can be reset
 
-        // When a game fires DXGI event 42, we prefer it over DxgKrnl to avoid double-counting.
-        // Some DX12 games emit both — this flag suppresses DxgKrnl once DXGI is confirmed active
-        // for the current PID. Resets on every PID switch.
-        private bool _dxgiActiveForCurrentPid = false;
-        private bool _flipActiveForCurrentPid = false;
-
         // Rolling-window FPS using EventHeader.TimeStamp (raw QPC ticks at Present call time).
         // Critical: ETW batches events and delivers them all at once, so Stopwatch.GetTimestamp()
         // at callback time is nearly identical for every frame in the batch — causing fps = N/~0.
@@ -278,27 +256,25 @@ namespace GHelper.Overlay
 
         private void PauseProviders()
         {
-            EnableTraceEx2(_sessionHandle, DxgiProviderId,    EVENT_CONTROL_CODE_DISABLE_PROVIDER, 0, 0, 0, 0, IntPtr.Zero);
             EnableTraceEx2(_sessionHandle, DxgKrnlProviderId, EVENT_CONTROL_CODE_DISABLE_PROVIDER, 0, 0, 0, 0, IntPtr.Zero);
         }
 
         private void ApplyKernelFilters(int pid)
         {
-            EnableProviderWithFilters(DxgiProviderId,    0,                       pid, applyDxgiEventIdFilter: true);
-            EnableProviderWithFilters(DxgKrnlProviderId, DXGKRNL_KEYWORD_PRESENT, pid, applyDxgiEventIdFilter: false);
+            EnableProviderWithFilters(DxgKrnlProviderId, DXGKRNL_KEYWORD_PRESENT, pid, EVENT_DXGKRNL_PRESENT_INFO);
         }
 
-        // Re-enables a provider with EVENT_FILTER_TYPE_PID (+ EVENT_FILTER_TYPE_EVENT_ID for
-        // DXGI) so the kernel drops events from other processes before delivering them.
+        // Re-enables a provider with EVENT_FILTER_TYPE_PID + EVENT_FILTER_TYPE_EVENT_ID so the
+        // kernel drops events from other processes and other event ids before delivering them.
         // ETW copies all filter buffers internally — they're freed immediately in the finally.
-        private void EnableProviderWithFilters(Guid providerId, ulong keyword, int pid, bool applyDxgiEventIdFilter)
+        private void EnableProviderWithFilters(Guid providerId, ulong keyword, int pid, ushort filterEventId)
         {
-            int filterCount = applyDxgiEventIdFilter ? 2 : 1;
-            int descSize    = Marshal.SizeOf<EVENT_FILTER_DESCRIPTOR>();
+            const int filterCount = 2;
+            int descSize = Marshal.SizeOf<EVENT_FILTER_DESCRIPTOR>();
 
             IntPtr descs      = Marshal.AllocHGlobal(filterCount * descSize);
             IntPtr pidBuf     = Marshal.AllocHGlobal(sizeof(uint));
-            IntPtr eventIdBuf = applyDxgiEventIdFilter ? Marshal.AllocHGlobal(8) : IntPtr.Zero;
+            IntPtr eventIdBuf = Marshal.AllocHGlobal(8);
             IntPtr paramsPtr  = Marshal.AllocHGlobal(Marshal.SizeOf<ENABLE_TRACE_PARAMETERS>());
 
             try
@@ -312,23 +288,20 @@ namespace GHelper.Overlay
                 };
                 Marshal.StructureToPtr(pidDesc, descs, false);
 
-                if (applyDxgiEventIdFilter)
-                {
-                    // EVENT_FILTER_EVENT_ID: BOOLEAN FilterIn; UCHAR Reserved; USHORT Count;
-                    // USHORT Events[Count]. For Count=1 the descriptor is 6 bytes.
-                    Marshal.WriteByte (eventIdBuf, 0, 1);                        // FilterIn = true
-                    Marshal.WriteByte (eventIdBuf, 1, 0);                        // Reserved
-                    Marshal.WriteInt16(eventIdBuf, 2, 1);                        // Count = 1
-                    Marshal.WriteInt16(eventIdBuf, 4, EVENT_DXGI_PRESENT_START); // Events[0] = 42
+                // EVENT_FILTER_EVENT_ID: BOOLEAN FilterIn; UCHAR Reserved; USHORT Count;
+                // USHORT Events[Count]. For Count=1 the descriptor is 6 bytes.
+                Marshal.WriteByte (eventIdBuf, 0, 1);                    // FilterIn = true
+                Marshal.WriteByte (eventIdBuf, 1, 0);                    // Reserved
+                Marshal.WriteInt16(eventIdBuf, 2, 1);                    // Count = 1
+                Marshal.WriteInt16(eventIdBuf, 4, (short)filterEventId); // Events[0]
 
-                    var eidDesc = new EVENT_FILTER_DESCRIPTOR
-                    {
-                        Ptr  = (ulong)eventIdBuf.ToInt64(),
-                        Size = 6,
-                        Type = EVENT_FILTER_TYPE_EVENT_ID,
-                    };
-                    Marshal.StructureToPtr(eidDesc, descs + descSize, false);
-                }
+                var eidDesc = new EVENT_FILTER_DESCRIPTOR
+                {
+                    Ptr  = (ulong)eventIdBuf.ToInt64(),
+                    Size = 6,
+                    Type = EVENT_FILTER_TYPE_EVENT_ID,
+                };
+                Marshal.StructureToPtr(eidDesc, descs + descSize, false);
 
                 var enableParams = new ENABLE_TRACE_PARAMETERS
                 {
@@ -384,16 +357,8 @@ namespace GHelper.Overlay
             if (hr != ERROR_SUCCESS)
                 throw new InvalidOperationException($"StartTrace failed: 0x{hr:X}");
 
-            // 2a. Subscribe to the DXGI provider (DX11 + DX12 games that go through
-            //     the user-mode DXGI swapchain — fires event ID 42 per frame).
-            EnableTraceEx2(_sessionHandle, DxgiProviderId,
-                EVENT_CONTROL_CODE_ENABLE_PROVIDER,
-                TRACE_LEVEL_INFORMATION, 0, 0, 0, IntPtr.Zero);
-
-            // 2b. Subscribe to the DxgKrnl provider (DX12 flip-model + Vulkan games
-            //     that call D3DKMTPresent directly and never surface a DXGI event 42).
-            //     DXGKRNL_KEYWORD_PRESENT scopes delivery to flip/present events only,
-            //     avoiding the high volume of all kernel GPU scheduling events.
+            // 2. Subscribe to the DxgKrnl provider — Present_Info fires once per frame
+            //    for every graphics API.
             EnableTraceEx2(_sessionHandle, DxgKrnlProviderId,
                 EVENT_CONTROL_CODE_ENABLE_PROVIDER,
                 TRACE_LEVEL_INFORMATION, DXGKRNL_KEYWORD_PRESENT, 0, 0, IntPtr.Zero);
@@ -460,60 +425,21 @@ namespace GHelper.Overlay
 
         private void OnEventRecord(ref EVENT_RECORD record)
         {
-            // DXGI PresentStart — DX11 and DX12 games using the DXGI user-mode swapchain path
-            bool isDxgiPresent = record.EventHeader.ProviderId == DxgiProviderId
-                              && record.EventHeader.Id == EVENT_DXGI_PRESENT_START;
-
-            // DxgKrnl Flip_Start — DX12 flip-model and Vulkan games (e.g. KCD2) that call
-            // D3DKMTPresent via the kernel without surfacing a DXGI event 42.
-            // Task=14 (Flip), Opcode=1 (Start) fires once per submitted flip-model frame.
-            bool isDxgKrnlFlip = record.EventHeader.ProviderId == DxgKrnlProviderId
-                              && record.EventHeader.Task == DXGKRNL_TASK_FLIP
-                              && record.EventHeader.Opcode == DXGKRNL_OPCODE_START;
-
-            bool isDxgKrnlBlitPresent = record.EventHeader.ProviderId == DxgKrnlProviderId
-                                     && record.EventHeader.Id == EVENT_DXGKRNL_PRESENT_INFO;
-
-            if (!isDxgiPresent && !isDxgKrnlFlip && !isDxgKrnlBlitPresent) return;
+            if (record.EventHeader.ProviderId != DxgKrnlProviderId
+                || record.EventHeader.Id != EVENT_DXGKRNL_PRESENT_INFO) return;
 
             int targetPid = _targetPid;
             if (targetPid == 0) return;                                    // no foreground target yet
             if ((int)record.EventHeader.ProcessId != targetPid) return;    // wrong process
 
-            // PID changed — reset rolling window so stale timestamps don't pollute new readings.
-            // Runs before the preference latches so a stale one can't mute the new process.
+            // PID changed — reset rolling window so stale timestamps don't pollute new readings
             if (targetPid != _lastTargetPid)
             {
                 _lastTargetPid = targetPid;
                 _frameHead = 0;
                 _framesFilled = 0;
-                _dxgiActiveForCurrentPid = false;
-                _flipActiveForCurrentPid = false;
                 return;
             }
-
-            // DXGI_PRESENT_TEST presents probe swapchain state without displaying a frame.
-            // S.T.A.L.K.E.R. Anomaly's X-Ray engine fires one between every real Present,
-            // which would otherwise double the reported FPS. Skip them — by definition
-            // they never produce a displayed frame, so this is safe for any game.
-            if (isDxgiPresent && record.UserDataLength >= 12)
-            {
-                uint dxgiFlags = (uint)Marshal.ReadInt32(record.UserData, 8);
-                if ((dxgiFlags & 0x1 /*DXGI_PRESENT_TEST*/) != 0) return;
-            }
-
-            // Prefer DXGI when available — if DXGI event 42 has been seen for this PID,
-            // ignore DxgKrnl events to avoid double-counting frames on games that emit both.
-            if (isDxgiPresent)
-                _dxgiActiveForCurrentPid = true;
-            else if (_dxgiActiveForCurrentPid)
-                return;
-
-            // Same one tier down: prefer Flip over blit Present_Info (flip games emit both).
-            if (isDxgKrnlFlip)
-                _flipActiveForCurrentPid = true;
-            else if (isDxgKrnlBlitPresent && _flipActiveForCurrentPid)
-                return;
 
             // EventHeader.TimeStamp = kernel QPC tick at the moment Present() was called.
             // This is NOT affected by ETW delivery batching, giving accurate inter-frame timing.

--- a/app/Overlay/EtwFpsMonitor.cs
+++ b/app/Overlay/EtwFpsMonitor.cs
@@ -26,9 +26,8 @@ namespace GHelper.Overlay
         // Keyword bit carrying Present_Info — keeps high-volume kernel GPU events out
         private const ulong DXGKRNL_KEYWORD_PRESENT = 0x0000000008000000UL;
 
-        // Kernel-side filter descriptors — applied once on first known foreground PID so we
-        // stop receiving events from every other GPU process system-wide.
-        private const uint EVENT_FILTER_TYPE_PID             = 0x80000004;
+        // Kernel-side event-id filter — only Present_Info is delivered to the session.
+        // (EVENT_FILTER_TYPE_PID is ignored by kernel-mode providers — PID is matched in the callback.)
         private const uint EVENT_FILTER_TYPE_EVENT_ID        = 0x80000200;
         private const uint ENABLE_TRACE_PARAMETERS_VERSION_2 = 2;
 
@@ -213,7 +212,6 @@ namespace GHelper.Overlay
         private System.Threading.Timer? _flushTimer;
         private long _lastFlushTick;             // ≥1 s flush floor
         private volatile int _targetPid = -1;
-        private int _lastTargetPid;       // detects PID switches so the window can be reset
 
         // Rolling-window FPS using EventHeader.TimeStamp (raw QPC ticks at Present call time).
         // Critical: ETW batches events and delivers them all at once, so Stopwatch.GetTimestamp()
@@ -225,12 +223,6 @@ namespace GHelper.Overlay
         private volatile int _frameHead = 0;    // next write slot — read by overlay tick thread
         private volatile int _framesFilled = 0; // valid entries (capped at RollingWindowSize)
 
-        // Flip true to log ETW delivery latency once per second (see LogFpsDiagnostics).
-        private static readonly bool FpsDiagLogging = false;
-        private long _diagStart, _diagLastEvent;
-        private int _diagFrames;
-        private double _diagLatMin, _diagLatMax, _diagLatSum, _diagGapMax;
-
         private EventRecordCallback? _callbackRef; // keep delegate alive — prevents GC collection
 
         /// Set to the foreground process PID to filter events.
@@ -241,91 +233,65 @@ namespace GHelper.Overlay
             set
             {
                 if (_targetPid == value) return;
+                bool wasPaused = _targetPid == 0;
                 _targetPid = value;
+                _frameHead = 0;
+                _framesFilled = 0;
                 if (_sessionHandle == 0) return;
-                // Push the kernel-side filter on every foreground PID change. One-shot
-                // doesn't work: if the user launches a game while the overlay is already
-                // open, the kernel filter would stay pinned to the previous foreground
-                // and events from the new game would be dropped before reaching us.
                 if (value == 0)
-                    PauseProviders();
-                else
-                    ApplyKernelFilters(value);
+                    EnableTraceEx2(_sessionHandle, DxgKrnlProviderId, EVENT_CONTROL_CODE_DISABLE_PROVIDER, 0, 0, 0, 0, IntPtr.Zero);
+                else if (wasPaused)
+                    EnableProvider();
             }
         }
 
-        private void PauseProviders()
+        // ETW copies the filter buffers internally — they're freed immediately in the finally.
+        private void EnableProvider()
         {
-            EnableTraceEx2(_sessionHandle, DxgKrnlProviderId, EVENT_CONTROL_CODE_DISABLE_PROVIDER, 0, 0, 0, 0, IntPtr.Zero);
-        }
-
-        private void ApplyKernelFilters(int pid)
-        {
-            EnableProviderWithFilters(DxgKrnlProviderId, DXGKRNL_KEYWORD_PRESENT, pid, EVENT_DXGKRNL_PRESENT_INFO);
-        }
-
-        // Re-enables a provider with EVENT_FILTER_TYPE_PID + EVENT_FILTER_TYPE_EVENT_ID so the
-        // kernel drops events from other processes and other event ids before delivering them.
-        // ETW copies all filter buffers internally — they're freed immediately in the finally.
-        private void EnableProviderWithFilters(Guid providerId, ulong keyword, int pid, ushort filterEventId)
-        {
-            const int filterCount = 2;
-            int descSize = Marshal.SizeOf<EVENT_FILTER_DESCRIPTOR>();
-
-            IntPtr descs      = Marshal.AllocHGlobal(filterCount * descSize);
-            IntPtr pidBuf     = Marshal.AllocHGlobal(sizeof(uint));
+            IntPtr desc       = Marshal.AllocHGlobal(Marshal.SizeOf<EVENT_FILTER_DESCRIPTOR>());
             IntPtr eventIdBuf = Marshal.AllocHGlobal(8);
             IntPtr paramsPtr  = Marshal.AllocHGlobal(Marshal.SizeOf<ENABLE_TRACE_PARAMETERS>());
 
             try
             {
-                Marshal.WriteInt32(pidBuf, pid);
-                var pidDesc = new EVENT_FILTER_DESCRIPTOR
-                {
-                    Ptr  = (ulong)pidBuf.ToInt64(),
-                    Size = sizeof(uint),
-                    Type = EVENT_FILTER_TYPE_PID,
-                };
-                Marshal.StructureToPtr(pidDesc, descs, false);
-
                 // EVENT_FILTER_EVENT_ID: BOOLEAN FilterIn; UCHAR Reserved; USHORT Count;
                 // USHORT Events[Count]. For Count=1 the descriptor is 6 bytes.
-                Marshal.WriteByte (eventIdBuf, 0, 1);                    // FilterIn = true
-                Marshal.WriteByte (eventIdBuf, 1, 0);                    // Reserved
-                Marshal.WriteInt16(eventIdBuf, 2, 1);                    // Count = 1
-                Marshal.WriteInt16(eventIdBuf, 4, (short)filterEventId); // Events[0]
+                Marshal.WriteByte (eventIdBuf, 0, 1);                                    // FilterIn = true
+                Marshal.WriteByte (eventIdBuf, 1, 0);                                    // Reserved
+                Marshal.WriteInt16(eventIdBuf, 2, 1);                                    // Count = 1
+                Marshal.WriteInt16(eventIdBuf, 4, (short)EVENT_DXGKRNL_PRESENT_INFO);    // Events[0]
 
-                var eidDesc = new EVENT_FILTER_DESCRIPTOR
+                Marshal.StructureToPtr(new EVENT_FILTER_DESCRIPTOR
                 {
                     Ptr  = (ulong)eventIdBuf.ToInt64(),
                     Size = 6,
                     Type = EVENT_FILTER_TYPE_EVENT_ID,
-                };
-                Marshal.StructureToPtr(eidDesc, descs + descSize, false);
+                }, desc, false);
 
-                var enableParams = new ENABLE_TRACE_PARAMETERS
+                Marshal.StructureToPtr(new ENABLE_TRACE_PARAMETERS
                 {
                     Version          = ENABLE_TRACE_PARAMETERS_VERSION_2,
-                    EnableFilterDesc = descs,
-                    FilterDescCount  = (uint)filterCount,
-                };
-                Marshal.StructureToPtr(enableParams, paramsPtr, false);
+                    EnableFilterDesc = desc,
+                    FilterDescCount  = 1,
+                }, paramsPtr, false);
 
-                uint hr = EnableTraceEx2(_sessionHandle, providerId,
+                uint hr = EnableTraceEx2(_sessionHandle, DxgKrnlProviderId,
                     EVENT_CONTROL_CODE_ENABLE_PROVIDER,
-                    TRACE_LEVEL_INFORMATION, keyword, 0, 0, paramsPtr);
-                // Log on failure so a regression like the previous attempt is observable next
-                // time. Failure here is non-fatal: providers were already enabled unfiltered
-                // in Start(), so callback-side filtering continues to work.
+                    TRACE_LEVEL_INFORMATION, DXGKRNL_KEYWORD_PRESENT, 0, 0, paramsPtr);
                 if (hr != ERROR_SUCCESS)
-                    Logger.WriteLine($"EnableTraceEx2 (filter) failed for {providerId}: 0x{hr:X}");
+                {
+                    Logger.WriteLine($"EnableTraceEx2 (filter) failed: 0x{hr:X}");
+                    // Fall back to unfiltered enable — the callback filters by event id anyway
+                    EnableTraceEx2(_sessionHandle, DxgKrnlProviderId,
+                        EVENT_CONTROL_CODE_ENABLE_PROVIDER,
+                        TRACE_LEVEL_INFORMATION, DXGKRNL_KEYWORD_PRESENT, 0, 0, IntPtr.Zero);
+                }
             }
             finally
             {
                 Marshal.FreeHGlobal(paramsPtr);
-                if (eventIdBuf != IntPtr.Zero) Marshal.FreeHGlobal(eventIdBuf);
-                Marshal.FreeHGlobal(pidBuf);
-                Marshal.FreeHGlobal(descs);
+                Marshal.FreeHGlobal(eventIdBuf);
+                Marshal.FreeHGlobal(desc);
             }
         }
 
@@ -359,9 +325,7 @@ namespace GHelper.Overlay
 
             // 2. Subscribe to the DxgKrnl provider — Present_Info fires once per frame
             //    for every graphics API.
-            EnableTraceEx2(_sessionHandle, DxgKrnlProviderId,
-                EVENT_CONTROL_CODE_ENABLE_PROVIDER,
-                TRACE_LEVEL_INFORMATION, DXGKRNL_KEYWORD_PRESENT, 0, 0, IntPtr.Zero);
+            EnableProvider();
 
             // 3. Open the real-time consumer using explicit-layout struct.
             //    LoggerName and EventRecordCallback are marshaled as raw IntPtrs to
@@ -429,25 +393,13 @@ namespace GHelper.Overlay
                 || record.EventHeader.Id != EVENT_DXGKRNL_PRESENT_INFO) return;
 
             int targetPid = _targetPid;
-            if (targetPid == 0) return;                                    // no foreground target yet
-            if ((int)record.EventHeader.ProcessId != targetPid) return;    // wrong process
-
-            // PID changed — reset rolling window so stale timestamps don't pollute new readings
-            if (targetPid != _lastTargetPid)
-            {
-                _lastTargetPid = targetPid;
-                _frameHead = 0;
-                _framesFilled = 0;
-                return;
-            }
+            if (targetPid <= 0 || (int)record.EventHeader.ProcessId != targetPid) return;
 
             // EventHeader.TimeStamp = kernel QPC tick at the moment Present() was called.
             // This is NOT affected by ETW delivery batching, giving accurate inter-frame timing.
             _frameTimes[_frameHead] = record.EventHeader.TimeStamp;
             _frameHead = (_frameHead + 1) % RollingWindowSize;
             if (_framesFilled < RollingWindowSize) _framesFilled++;
-
-            if (FpsDiagLogging) LogFpsDiagnostics(record.EventHeader.TimeStamp);
         }
 
         // FPS averaged over the last second of frames; 0 when nothing rendered in the last second.
@@ -478,38 +430,6 @@ namespace GHelper.Overlay
             double elapsed = (double)(newest - oldest) / freq;
             if (elapsed <= 0) return 0;
             return (count - 1) / elapsed;
-        }
-
-        // Logs ETW delivery latency (now − Present) and the max delivery gap, once per second.
-        private void LogFpsDiagnostics(long presentTick)
-        {
-            long freq = Stopwatch.Frequency;
-            long nowTick = Stopwatch.GetTimestamp();
-            double latMs = (double)(nowTick - presentTick) / freq * 1000.0;
-            if (_diagFrames == 0) { _diagLatMin = _diagLatMax = latMs; }
-            else
-            {
-                if (latMs < _diagLatMin) _diagLatMin = latMs;
-                if (latMs > _diagLatMax) _diagLatMax = latMs;
-            }
-            _diagLatSum += latMs;
-            if (_diagLastEvent != 0)
-            {
-                double gapMs = (double)(nowTick - _diagLastEvent) / freq * 1000.0;
-                if (gapMs > _diagGapMax) _diagGapMax = gapMs;
-            }
-            _diagLastEvent = nowTick;
-            _diagFrames++;
-            if (_diagStart == 0) _diagStart = nowTick;
-            else if (nowTick - _diagStart >= freq)
-            {
-                double secs = (double)(nowTick - _diagStart) / freq;
-                Logger.WriteLine(
-                    $"FPS diag: fps={SampleFps():F0} frames={_diagFrames} rate={_diagFrames / secs:F0}/s | " +
-                    $"ETW latency ms: min={_diagLatMin:F0} avg={_diagLatSum / _diagFrames:F0} max={_diagLatMax:F0} | " +
-                    $"maxgap={_diagGapMax:F0}ms");
-                _diagStart = nowTick; _diagFrames = 0; _diagLatSum = 0; _diagGapMax = 0;
-            }
         }
 
         private static EVENT_TRACE_PROPERTIES BuildSessionProperties() => new()

--- a/app/Overlay/HardwareOverlay.cs
+++ b/app/Overlay/HardwareOverlay.cs
@@ -149,6 +149,7 @@ namespace GHelper.Overlay
 
         // Cached drawing resources — recreated only when the scale changes
         private float _lastScale = 0f;
+        private float _charW;
         private Font? _font;
         private Font? _rpmFont;
         private Font? _iGpuFont;
@@ -647,15 +648,14 @@ namespace GHelper.Overlay
                 _fpsBold?.Dispose(); _fpsBold = new Font("Consolas", innerH / 1.15f, FontStyle.Bold, GraphicsUnit.Pixel);
                 _totalPen?.Dispose(); _totalPen = new Pen(Color.FromArgb(255, 200, 200, 200), sc * 0.75f) { DashStyle = DashStyle.Dot };
                 _axPen?.Dispose();    _axPen    = new Pen(Color.FromArgb(255, 80, 80, 80), sc * 0.5f);
+                _charW = g.MeasureString("XX", _font).Width - g.MeasureString("X", _font).Width;
             }
 
             var font    = _font!;
             var rpmFont = _rpmFont!;
             var fpsBold = _fpsBold!;
 
-            // Differential trick: MeasureString("XX") - MeasureString("X") cancels the
-            // fixed GDI+ padding, giving the true per-character advance width for Consolas.
-            float charW = g.MeasureString("XX", font).Width - g.MeasureString("X", font).Width;
+            float charW = _charW;
 
             int topY = padY;
             // Nudge per-row text down so it lines up with the vertically centered usage bars.

--- a/app/Overlay/HardwareOverlay.cs
+++ b/app/Overlay/HardwareOverlay.cs
@@ -210,6 +210,8 @@ namespace GHelper.Overlay
         private IntPtr _fgHook;
         private WinEventProc? _fgHookProc; // keep delegate alive
         private const int MinGameFps = 6;
+        private const int GameLatchTicks = 2;
+        private int _gameTicks;
 
         private static readonly HashSet<string> DesktopApps = new(StringComparer.OrdinalIgnoreCase)
         {
@@ -521,7 +523,9 @@ namespace GHelper.Overlay
 
         private void UpdateGameVisibility(int fgPid)
         {
-            if (_currentFps >= MinGameFps && !_fgDesktop) _shownPid = fgPid;
+            // sustained fps only — Present_Info also fires for app repaint bursts
+            _gameTicks = _currentFps >= MinGameFps && !_fgDesktop ? _gameTicks + 1 : 0;
+            if (_gameTicks >= GameLatchTicks) _shownPid = fgPid;
             bool show = fgPid == _shownPid;
             if (show != _hidden) return;
             _hidden = !show;

--- a/app/Overlay/HardwareOverlay.cs
+++ b/app/Overlay/HardwareOverlay.cs
@@ -91,6 +91,7 @@ namespace GHelper.Overlay
         //
         private const float BaseFontSize = 13f;
         private const float BaseRpmFontSize = 8.5f;
+        private const float BaseIGpuFontSize = 10.5f;
         private const int BaseLineHeight = 18;
         private const int BaseLineSpacing = 1;
         private const int BasePadX = 8;
@@ -150,6 +151,7 @@ namespace GHelper.Overlay
         private float _lastScale = 0f;
         private Font? _font;
         private Font? _rpmFont;
+        private Font? _iGpuFont;
         private Font? _fpsBold;
         private Pen? _totalPen;
         private Pen? _axPen;
@@ -163,6 +165,7 @@ namespace GHelper.Overlay
         // _gpuTempStr includes a trailing space so fan number has breathing room
         private string _gpuTempStr = "";
         private string _cpuTempStr = "";
+        private bool _isIGpu;
         private string _gpuFanNum = "";
         private string _cpuFanNum = "";
         private string _gpuPow = "";
@@ -457,6 +460,7 @@ namespace GHelper.Overlay
             bool gpuActive = gpuTemp > 0;
 
             // Trailing space is the separator between temp and fan number
+            _isIGpu = HardwareControl.IsIGpu;
             _gpuTempStr = "GPU:" + FmtTemp(gpuTemp) + " ";
             _cpuTempStr = "CPU:" + FmtTemp(cpuTemp) + " ";
             _gpuFanNum = FormatFan(HardwareControl.gpuFanRPM);
@@ -635,6 +639,7 @@ namespace GHelper.Overlay
                 _lastScale = sc;
                 _font?.Dispose();    _font    = new Font("Consolas", BaseFontSize * sc, FontStyle.Regular, GraphicsUnit.Pixel);
                 _rpmFont?.Dispose(); _rpmFont = new Font("Consolas", BaseRpmFontSize * sc, FontStyle.Regular, GraphicsUnit.Pixel);
+                _iGpuFont?.Dispose(); _iGpuFont = new Font("Consolas", BaseIGpuFontSize * sc, FontStyle.Regular, GraphicsUnit.Pixel);
                 _fpsBold?.Dispose(); _fpsBold = new Font("Consolas", innerH / 1.15f, FontStyle.Bold, GraphicsUnit.Pixel);
                 _totalPen?.Dispose(); _totalPen = new Pen(Color.FromArgb(255, 200, 200, 200), sc * 0.75f) { DashStyle = DashStyle.Dot };
                 _axPen?.Dispose();    _axPen    = new Pen(Color.FromArgb(255, 80, 80, 80), sc * 0.5f);
@@ -671,6 +676,8 @@ namespace GHelper.Overlay
             }
 
             // Left column: fan RPM hidden in Light mode
+            if (showTemp && _isIGpu)
+                g.DrawString("i", _iGpuFont!, _gpuBrush, new PointF(leftX - charW * (BaseIGpuFontSize / BaseFontSize), textY + font.Height - _iGpuFont!.Height));
             DrawTempFan(g, font, rpmFont, charW, sc, leftX, textY, showTemp ? _gpuTempStr : "", showFans ? _gpuFanNum : "", _gpuBrush);
             DrawTempFan(g, font, rpmFont, charW, sc, leftX, textY + lineH + lineGap, showTemp ? _cpuTempStr : "", showFans ? _cpuFanNum : "", _cpuBrush);
 
@@ -1117,6 +1124,7 @@ namespace GHelper.Overlay
 
             _font?.Dispose();     _font     = null;
             _rpmFont?.Dispose();  _rpmFont  = null;
+            _iGpuFont?.Dispose(); _iGpuFont = null;
             _fpsBold?.Dispose();  _fpsBold  = null;
             _totalPen?.Dispose(); _totalPen = null;
             _axPen?.Dispose();    _axPen    = null;


### PR DESCRIPTION
## Summary  This is an incremental fix for #5719 on a ROG Flow Z13 GZ302EA with Radeon 8060S (Strix Halo).  On this device ADL enumerates five duplicate adapters with `VendorID = -1002`. `ADL2_Adapter_ASICFamilyType_Get` returns `-8` for every index, so the integrated adapter is never selected. Even after selecting it, `ADL2_New_QueryPMLogData_Get` returns `-8` for all five indices; the legacy Overdrive temperature and performance APIs return `-5`.  The patch:  - accepts the signed AMD vendor ID and uses the configured AMD-iGPU fallback when ASIC family classification is unavailable; - keeps ADL PMLog as the preferred source; - uses AMD ADLX as the primary fallback for temperature, utilization, current VRAM and GPU power; - keeps Windows `D3DKMT_ADAPTER_PERFDATA`, matching-LUID `GPU Engine` counters and video-memory information as final fallbacks; - stops deriving iGPU power by subtracting per-core Energy Meter counters from the CPU package counter; - uses the sum of the per-core RAPL Energy Meter counters for AMD Software-compatible CPU power, while retaining package power only as a generic fallback on other systems.  ## Verification  - `dotnet build app/GHelper.csproj -c Release --no-restore`: succeeded with 0 warnings and 0 errors. - `dotnet publish app/GHelper.csproj -c Release -r win-x64 --self-contained false -p:PublishSingleFile=true --no-restore`: succeeded. - Runtime on GZ302EA / Radeon 8060S / driver 32.0.23033.5002:   - ADLX temperature and utilization match AMD Software sampling much more closely than the Windows busiest-engine fallback;   - ADLX VRAM current usage is returned correctly on the UMA adapter;   - under the same active workload, ADLX `GPUPower` reported 50-62 W while the old package-minus-core estimate was around 10-20 W;   - ADLX `GPUTotalBoardPower` is unsupported/zero on this APU, so `GPUPower` is used;   - same-screen comparison: AMD Software CPU power was 25.9 W and the 16 per-core RAPL counters summed to about 25.9 W, while `RAPL_Package0_PKG` was 48-54 W because it includes shared APU/GPU domains.  The ADLX path uses `ADLXInitializeWithIncompatibleDriver`, because regular `ADLXInitialize` returns an empty GPU list with this OEM driver.