### PR TITLE
fixed OLED not being detected for ASUS Vivobook 14 Flip TP3407

### DIFF
--- a/app/AppConfig.cs
+++ b/app/AppConfig.cs
@@ -477,7 +477,12 @@ public static class AppConfig
         try
         {
             var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\ASUS\OLEDCare");
-            return key is not null && Convert.ToInt32(key.GetValue("EnablePixelRefresh", 0)) != 0;
+            if (key is not null && Convert.ToInt32(key.GetValue("EnablePixelRefresh", 0)) != 0) return true;
+
+            key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\ASUS\ASUS System Control Interface\AsusOptimization\ASUS Keyboard Hotkeys");
+            if (key is not null && Convert.ToInt32(key.GetValue("OLEDPanel", 0)) != 0) return true;
+
+            return false;
         }
         catch { return false; }
     });


### PR DESCRIPTION
Flicker-free dimming option was not showing up for my laptop, ASUS Vivobook 14 Flip TP3407SA. I found that the function IsOLED() was returning false.

One solution was to add my laptop's model to the list of ContainsModel() checks. But I found that my laptop has different registry entries for OLED. The closest thing to "SOFTWARE\ASUS\OLEDCare" was:

<img width="797" height="209" alt="oled care" src="https://github.com/user-attachments/assets/7311d46a-b838-48b2-8243-a6085c54851c" />

But the OLED related values are present here:

<img width="911" height="274" alt="oled values" src="https://github.com/user-attachments/assets/f2f3ea9c-4434-4f60-b9ec-9ad92a167663" />

Adding an additional read for OLEDPanel value fixed the issue. IsOLED() returned true and Flicker-free dimming bar showed up when running the compiled application.