### PR TITLE
Copy from CPU buttons for GPU and Mid fan curves

### DIFF
--- a/app/Fans.cs
+++ b/app/Fans.cs
@@ -175,6 +175,9 @@ namespace GHelper
             checkApplyFans.Click += CheckApplyFans_Click;
             checkApplyPower.Click += CheckApplyPower_Click;
 
+            AddCopyFromCpuButton(chartGPU, seriesGPU, AsusFan.GPU);
+            AddCopyFromCpuButton(chartMid, seriesMid, AsusFan.Mid);
+
             trackGPUClockLimit.Minimum = NvidiaGpuControl.MinClockLimit;
             trackGPUClockLimit.Maximum = NvidiaGpuControl.MaxClockLimit;
 
@@ -971,6 +974,45 @@ namespace GHelper
             AppConfig.SetMode("auto_apply", chk.Checked ? 1 : 0);
             modeControl.SetPerformanceMode();
 
+        }
+
+        // Small overlay button in the top-right corner of a chart that copies the CPU curve into it
+        private void AddCopyFromCpuButton(Chart chart, Series target, AsusFan device)
+        {
+            float dpi = ControlHelper.GetDpiScale(this).Value;
+
+            // Theme colors: buttonSecond is nearly identical to the chart background, so the button blends in
+            RButton button = new RButton
+            {
+                Activated = false,
+                BackColor = RForm.buttonSecond,
+                ForeColor = RForm.foreMain,
+                BorderColor = Color.Transparent,
+                BorderRadius = 2,
+                FlatStyle = FlatStyle.Flat,
+                Font = new Font("Segoe UI", 8F, FontStyle.Regular, GraphicsUnit.Point, 0),
+                Secondary = true,
+                Size = new Size((int)(100 * dpi), (int)(18 * dpi)),
+                TabStop = false,
+                Text = Properties.Strings.FanCopyCpu,
+                UseVisualStyleBackColor = false,
+                Anchor = AnchorStyles.Top | AnchorStyles.Right,
+            };
+            button.FlatAppearance.BorderColor = RForm.borderSecond;
+
+            chart.Controls.Add(button);
+            button.Location = new Point(chart.ClientSize.Width - button.Width - (int)(8 * dpi), (int)(6 * dpi));
+
+            button.Click += (_, _) =>
+            {
+                if (seriesCPU.Points.Count != 8) return;
+
+                target.Points.Clear();
+                foreach (DataPoint point in seriesCPU.Points) target.Points.AddXY(point.XValue, point.YValues[0]);
+                SaveProfile(target, device);
+
+                if (AppConfig.IsApplyFans()) modeControl.AutoFans(); // push the copied curve to EC
+            };
         }
 
         public void InitAxis()

--- a/app/Properties/Strings.Designer.cs
+++ b/app/Properties/Strings.Designer.cs
@@ -1053,6 +1053,15 @@ namespace GHelper.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Copy from CPU.
+        /// </summary>
+        internal static string FanCopyCpu {
+            get {
+                return ResourceManager.GetString("FanCopyCpu", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Fan Profiles.
         /// </summary>
         internal static string FanProfiles {

--- a/app/Properties/Strings.resx
+++ b/app/Properties/Strings.resx
@@ -168,6 +168,9 @@
   <data name="ApplyFanCurve" xml:space="preserve">
     <value>Apply Fan Curve</value>
   </data>
+  <data name="FanCopyCpu" xml:space="preserve">
+    <value>Copy from CPU</value>
+  </data>
   <data name="ApplyPowerLimits" xml:space="preserve">
     <value>Apply Power Limits</value>
   </data>


### PR DESCRIPTION
Small QoL addition: a compact "Copy from CPU" button in the top-right corner of the GPU and Mid fan charts. One click copies the CPU curve into that chart, saves it for the current mode and re-applies it if "Apply Fan Curve" is enabled.

Motivation: on shared-heatsink models it is common to run all fans on the same curve, and drawing the same 8 points by hand two or three times is tedious.

Implementation notes:
- ~50 lines total, no Designer changes: the buttons are created in code and parented into the chart controls, so they only exist on charts that are visible (Mid button appears only on 3-fan models, XGM chart is intentionally left alone).
- Styled with the current theme colors (buttonSecond/foreMain/borderSecond), so they blend into the chart background in both light and dark themes; DPI-aware sizing.
- No behavior change unless the button is clicked.

![Fans window with Copy from CPU buttons](https://raw.githubusercontent.com/Lafnaps/g-helper/assets/copy-from-cpu-buttons.png)

