### PR TITLE
Fan curve axis calibration with measured duty to RPM tables

### DIFF
--- a/app/Fan/FanSensorControl.cs
+++ b/app/Fan/FanSensorControl.cs
@@ -122,6 +122,60 @@ namespace GHelper.Fan
             }
         }
 
+        // Optional per-fan duty->RPM calibration table (config fan_lut_N = "0:0,10:3700,...,100:5300").
+        // The chart Y axis assumes RPM is linear in duty, which is false for fans with a steep
+        // low end (Mid on GU604: 10% duty is already 3700 RPM) — a measured table fixes the labels.
+        static readonly Dictionary<int, (int duty, int rpm)[]?> _lutCache = new();
+
+        public static (int duty, int rpm)[]? GetLut(AsusFan device)
+        {
+            int i = (int)device;
+            if (_lutCache.TryGetValue(i, out var cached)) return cached;
+
+            (int, int)[]? parsed = null;
+            string? raw = AppConfig.GetString("fan_lut_" + i);
+            if (!string.IsNullOrEmpty(raw))
+            {
+                try
+                {
+                    parsed = raw.Split(',')
+                        .Select(p => { var kv = p.Split(':'); return (int.Parse(kv[0]), int.Parse(kv[1])); })
+                        .OrderBy(t => t.Item1).ToArray();
+                    if (parsed.Length < 2) parsed = null;
+                }
+                catch { parsed = null; }
+            }
+
+            _lutCache[i] = parsed;
+            return parsed;
+        }
+
+        public static int EvalLut((int duty, int rpm)[] lut, int percentage)
+        {
+            if (percentage <= 0) return lut[0].rpm;
+
+            // A stopped fan jumps straight to its minimum stable speed — interpolating
+            // into the 0-RPM anchor would fabricate speeds the fan can't physically do,
+            // so anything below the first measured running point clamps to that point
+            int start = 0;
+            while (start < lut.Length && lut[start].rpm <= 0) start++;
+            if (start >= lut.Length) return 0;
+            if (percentage <= lut[start].duty) return lut[start].rpm;
+
+            for (int i = start + 1; i < lut.Length; i++)
+            {
+                if (percentage <= lut[i].duty)
+                {
+                    int d0 = lut[i - 1].duty, d1 = lut[i].duty;
+                    int r0 = lut[i - 1].rpm, r1 = lut[i].rpm;
+                    if (d1 <= d0) return Math.Max(r0, r1);
+                    return r0 + (r1 - r0) * (percentage - d0) / (d1 - d0);
+                }
+            }
+
+            return lut[^1].rpm;
+        }
+
         public static string FormatFan(AsusFan device, int value)
         {
             if (value < 0) return null;
@@ -134,10 +188,24 @@ namespace GHelper.Fan
                 return Math.Min(Math.Round((float)value / GetFanMax(device) * 100), 100).ToString() + "%"; // relatively to max RPM
         }
 
+        // Phase 2 of calibration: a descending duty sweep (no start kicks) measuring the
+        // real duty->RPM point of every fan at each step, saved as fan_lut_N for the
+        // chart axis. Denser grid at the low end where fan curves bend the most.
+        static readonly int[] AXIS_DUTIES = { 90, 80, 70, 60, 55, 50, 45, 40, 35, 30, 25, 20, 15, 10, 5, 3 };
+        const int AXIS_SETTLE_TICKS = 8; // seconds to let RPM settle after each step
+        const int AXIS_SAMPLE_TICKS = 3; // tach samples averaged per step
+
+        static bool axisPhase;
+        static int axisStep;
+        static int axisTick;
+        static readonly int[] axisSum = new int[FAN_COUNT];
+        static readonly List<(int duty, int rpm)>[] axisPoints = new List<(int, int)>[FAN_COUNT];
+
         public void StartCalibration()
         {
 
             measuredMax = new int[] { 0, 0, 0 };
+            axisPhase = false;
             timer.Enabled = true;
 
             for (int i = 0; i < FAN_COUNT; i++)
@@ -145,13 +213,22 @@ namespace GHelper.Fan
 
             Program.acpi.DeviceSet(AsusACPI.PerformanceMode, AsusACPI.PerformanceTurbo, "ModeCalibration");
 
-            for (int i = 0; i < FAN_COUNT; i++)
-                Program.acpi.SetFanCurve((AsusFan)i, new byte[] { 20, 30, 40, 50, 60, 70, 80, 90, 100, 100, 100, 100, 100, 100, 100, 100 });
+            WriteFlatCurves(100);
+        }
 
+        static void WriteFlatCurves(int duty)
+        {
+            for (int i = 0; i < FAN_COUNT; i++)
+            {
+                byte d = (byte)duty;
+                Program.acpi.SetFanCurve((AsusFan)i, new byte[] { 20, 30, 40, 50, 60, 70, 80, 90, d, d, d, d, d, d, d, d });
+            }
         }
 
         private void Timer_Elapsed(object? sender, System.Timers.ElapsedEventArgs e)
         {
+            if (axisPhase) { AxisTick(); return; }
+
             int fan;
             bool same = true;
 
@@ -182,9 +259,85 @@ namespace GHelper.Fan
                 }
 
                 sameCount = 0;
-                FinishCalibration();
+                BeginAxisPhase();
             }
 
+        }
+
+        static void BeginAxisPhase()
+        {
+            for (int i = 0; i < FAN_COUNT; i++)
+            {
+                axisPoints[i] = new List<(int, int)>();
+                // the 100% point is the current sustained reading, not the transient peak
+                int now = Math.Max(0, Program.acpi.GetFan((AsusFan)i));
+                axisPoints[i].Add((100, now * 100));
+            }
+
+            axisPhase = true;
+            axisStep = 0;
+            axisTick = 0;
+            Array.Clear(axisSum);
+            WriteFlatCurves(AXIS_DUTIES[0]);
+        }
+
+        private void AxisTick()
+        {
+            int duty = AXIS_DUTIES[axisStep];
+            axisTick++;
+
+            fansForm.LabelFansResult($"Axis calibration {duty}% ({axisStep + 1}/{AXIS_DUTIES.Length}) - " +
+                $"CPU: {Math.Max(0, Program.acpi.GetFan(AsusFan.CPU)) * 100}, GPU: {Math.Max(0, Program.acpi.GetFan(AsusFan.GPU)) * 100}" +
+                (AppConfig.Is("mid_fan") ? $", Mid: {Math.Max(0, Program.acpi.GetFan(AsusFan.Mid)) * 100}" : ""));
+
+            if (axisTick <= AXIS_SETTLE_TICKS) return;
+
+            for (int i = 0; i < FAN_COUNT; i++)
+                axisSum[i] += Math.Max(0, Program.acpi.GetFan((AsusFan)i));
+
+            if (axisTick < AXIS_SETTLE_TICKS + AXIS_SAMPLE_TICKS) return;
+
+            for (int i = 0; i < FAN_COUNT; i++)
+                axisPoints[i].Add((duty, (int)Math.Round((double)axisSum[i] / AXIS_SAMPLE_TICKS) * 100));
+
+            Array.Clear(axisSum);
+            axisTick = 0;
+            axisStep++;
+
+            if (axisStep >= AXIS_DUTIES.Length)
+            {
+                SaveAxis();
+                axisPhase = false;
+                FinishCalibration();
+                return;
+            }
+
+            WriteFlatCurves(AXIS_DUTIES[axisStep]);
+        }
+
+        static void SaveAxis()
+        {
+            for (int i = 0; i < FAN_COUNT; i++)
+            {
+                var points = axisPoints[i].OrderBy(p => p.duty).ToList();
+
+                // no fan / dead tach — drop a stale table if any and move on
+                if (points.Count == 0 || points.Max(p => p.rpm) < 500)
+                {
+                    AppConfig.Remove("fan_lut_" + i);
+                    continue;
+                }
+
+                // measurement noise can dip against physics — enforce a non-decreasing curve
+                for (int k = 1; k < points.Count; k++)
+                    if (points[k].rpm < points[k - 1].rpm) points[k] = (points[k].duty, points[k - 1].rpm);
+
+                string lut = "0:0," + string.Join(",", points.Select(p => $"{p.duty}:{p.rpm}"));
+                AppConfig.Set("fan_lut_" + i, lut);
+                Logger.WriteLine($"Axis LUT {(AsusFan)i}: {lut}");
+            }
+
+            _lutCache.Clear();
         }
 
         private void FinishCalibration()

--- a/app/Fans.cs
+++ b/app/Fans.cs
@@ -796,13 +796,27 @@ namespace GHelper
         {
             if (percentage == 0) return "OFF";
 
-            int Min = FanSensorControl.GetFanMin(device);
-            int Max = FanSensorControl.GetFanMax(device);
+            if (!fanRpm) return percentage + "%";
 
-            if (fanRpm)
-                return (200 * Math.Floor((float)(Min * 100 + (Max - Min) * percentage) / 200)).ToString() + unit;
+            // Measured duty->RPM table beats the linear Min..Max guess when present;
+            // values are shown at the tach quantum (100), coarser rounding would
+            // reintroduce label-vs-tach mismatches
+            string rpm;
+            var lut = FanSensorControl.GetLut(device);
+            if (lut != null)
+            {
+                rpm = (100 * (int)Math.Round(FanSensorControl.EvalLut(lut, percentage) / 100.0, MidpointRounding.AwayFromZero)).ToString();
+            }
             else
-                return percentage + "%";
+            {
+                int Min = FanSensorControl.GetFanMin(device);
+                int Max = FanSensorControl.GetFanMax(device);
+                rpm = (200 * Math.Floor((float)(Min * 100 + (Max - Min) * percentage) / 200)).ToString();
+            }
+
+            // The drag tooltip (unit != "") also shows the duty: RPM is what you hear,
+            // duty is what actually gets written to the EC curve
+            return unit == "" ? rpm : rpm + unit + " (" + percentage + "%)";
         }
 
         void SetAxis(Chart chart, AsusFan device)


### PR DESCRIPTION
Chart Y-axis labels and point tooltips estimate RPM as a linear interpolation between `fan_min_N` and `fan_max_N`. The real duty-to-RPM response of the fans is not linear, so the displayed RPM can be quite far from what the tach actually reports. Extreme example: the mid fan on GU604 (Zephyrus M16) idles at 3600 RPM at 3% duty while its max is ~5500, so almost the whole lower half of the axis shows speeds the fan physically never runs at (e.g. "700 RPM").

This PR extends the existing **Calibrate** flow (Fans + Power → Power limits & Calibration → Calibrate) with a second phase. After the current max-RPM measurement it sweeps duty down through 90…3%, lets each step settle, samples the tach, and stores a per-fan table in config:

```
"fan_lut_0": "0:0,3:1900,10:2100,...,100:7000"
```

Axis labels and tooltips then interpolate this measured table; without a table everything falls back to the current linear estimate, so nothing changes for users who never calibrated (and for fans where measurement fails the key is simply not written).

Two smaller display changes along the way:

* RPM values are rounded to the tach quantum (100) instead of floored to 200, so labels can actually match what the Fans tooltip/tray shows.
* The drag tooltip now also shows the duty percent — RPM is what you hear, duty is what actually gets written to the EC curve: `3600RPM (34%)`.

Tested on GU604VY (all three fans calibrated in-app, labels now match tach readings across the whole curve).