### PR TITLE
No stale GPU temperature while dGPU sleeps, NVML power fallback for mobile RTX 40

### DIFF
--- a/app/Gpu/NVidia/NvidiaGpuControl.cs
+++ b/app/Gpu/NVidia/NvidiaGpuControl.cs
@@ -49,7 +49,6 @@ public class NvidiaGpuControl : IGpuControl
     public string FullName => _internalGpu!.FullName;
 
     public int? _lastTemp;
-    public int _lastTempTime = 0;
 
     private static bool verboseLog = false;
 
@@ -58,6 +57,14 @@ public class NvidiaGpuControl : IGpuControl
     private GpuState _lastState = GpuState.Off;
     private long _lastStateTime = -StateCacheMs;
     private const int StateCacheMs = 500; 
+
+    // A lightly-used GPU dips into RTD3 for sub-second stretches between polls;
+    // readings survive those dips and disappear only after a real sleep
+    private const int RecentActiveMs = 10_000;
+    private long _lastActiveTime = -RecentActiveMs;
+    private float _lastPower;
+
+    private bool WithinActiveGrace => Environment.TickCount64 - _lastActiveTime < RecentActiveMs;
 
     private GpuState GetGpuState()
     {
@@ -75,6 +82,7 @@ public class NvidiaGpuControl : IGpuControl
             _lastState = ex.Message == "NVAPI_GPU_NOT_POWERED" ? GpuState.Asleep : GpuState.Off;
         }
         _lastStateTime = Environment.TickCount64;
+        if (_lastState == GpuState.Active) _lastActiveTime = _lastStateTime;
         return _lastState;
     }
 
@@ -98,19 +106,21 @@ public class NvidiaGpuControl : IGpuControl
     {
         if (!IsValid) return null;
 
+        // A sleeping GPU has no meaningful "current" temperature: returning the
+        // cached value forever freezes a stale number in the UI and feeds the fan
+        // sync a reading from a chip that generates no heat. Not reading also lets
+        // the GPU actually stay asleep (the old refresh path woke it periodically
+        // just to update the cache). RTD3 dips within the grace keep the last value.
         var state = GetGpuState();
-        if (state == GpuState.Off) return null;
+        if (state != GpuState.Active)
+            return (state == GpuState.Asleep && WithinActiveGrace) ? _lastTemp : null;
 
-        if ((_readTask?.IsCompleted ?? true) && (state == GpuState.Active || ShouldRefresh()))
+        if (_readTask?.IsCompleted ?? true)
         {
             _readTask = Task.Run(() =>
             {
                 var temp = ReadCurrentTemperature();
-                if (temp is not null)
-                {
-                    _lastTemp = temp;
-                    _lastTempTime = Environment.TickCount;
-                }
+                if (temp is not null) _lastTemp = temp;
                 return temp;
             });
         }
@@ -118,29 +128,6 @@ public class NvidiaGpuControl : IGpuControl
         _readTask?.Wait(500);
 
         return _lastTemp;
-    }
-
-    private bool ShouldRefresh()
-    {
-        const int minInterval = 5_000;
-        const int maxInterval = 120_000;
-        const float deltaMin = 5f;
-        const float deltaMax = 20f;
-
-        if (_lastTemp is null) return true;
-
-        var cpuTemp = (float)HardwareControl.GetCPUTemp();
-        var delta = _lastTemp.Value - cpuTemp;
-
-        if (delta < deltaMin) return false;
-
-        var t = Math.Clamp((delta - deltaMin) / (deltaMax - deltaMin), 0f, 1f);
-        var interval = (int)(maxInterval - t * (maxInterval - minInterval));
-
-        var refresh = Environment.TickCount > _lastTempTime + interval;
-        if (verboseLog) Logger.WriteLine($"GPU Temp Refresh Interval: {interval}ms {refresh}");
-
-        return refresh;
     }
 
     public void Dispose()
@@ -374,8 +361,10 @@ public class NvidiaGpuControl : IGpuControl
             NvmlHelper.Shutdown();
             return null;
         }
-        if (state != GpuState.Active) return 0f;
-        return NvmlHelper.GetGpuPower() ?? 0f;
+        if (state != GpuState.Active)
+            return (state == GpuState.Asleep && WithinActiveGrace) ? _lastPower : 0f;
+        _lastPower = NvmlHelper.GetGpuPower() ?? 0f;
+        return _lastPower;
     }
 
     public (long usedMb, long totalMb)? GetVramInfo()

--- a/app/Gpu/NVidia/NvmlHelper.cs
+++ b/app/Gpu/NVidia/NvmlHelper.cs
@@ -10,11 +10,25 @@ public static class NvmlHelper
     [DllImport(NvmlDll)] static extern int nvmlDeviceGetTemperature(IntPtr device, uint sensorType, out uint temp);
     [DllImport(NvmlDll)] static extern int nvmlDeviceGetPowerUsage(IntPtr device, out uint powerMilliWatts);
     [DllImport(NvmlDll)] static extern int nvmlDeviceGetMemoryInfo(IntPtr device, out nvmlMemory_t memory);
+    [DllImport(NvmlDll)] static extern int nvmlDeviceGetFieldValues(IntPtr device, int valuesCount, nvmlFieldValue_t[] values);
 
     [StructLayout(LayoutKind.Sequential)]
     struct nvmlMemory_t { public ulong total; public ulong free; public ulong used; }
 
+    [StructLayout(LayoutKind.Sequential)]
+    struct nvmlFieldValue_t
+    {
+        public uint fieldId;
+        public uint scopeId;
+        public long timestamp;
+        public long latencyUsec;
+        public uint valueType;
+        public int nvmlReturn;
+        public ulong value; // union; power fields put milliwatts in the low uint
+    }
+
     const uint NVML_TEMPERATURE_GPU = 0;
+    const uint NVML_FI_DEV_POWER_INSTANT = 186;
     const int NVML_SUCCESS = 0;
 
     private static readonly object _lock = new();
@@ -60,9 +74,23 @@ public static class NvmlHelper
             try
             {
                 if (nvmlDeviceGetHandleByIndex_v2(gpuIndex, out IntPtr device) != NVML_SUCCESS) return null;
-                if (nvmlDeviceGetPowerUsage(device, out uint mW) != NVML_SUCCESS) return null;
-                if (mW > 200_000f) return null;
-                return mW / 1000f;
+
+                if (nvmlDeviceGetPowerUsage(device, out uint mW) == NVML_SUCCESS && mW > 0 && mW <= 200_000)
+                    return mW / 1000f;
+
+                // Mobile Ada (RTX 4090 Laptop, driver 2026-07): nvmlDeviceGetPowerUsage
+                // reports a bogus scale (~590 W at idle). nvidia-smi itself reads the
+                // POWER_INSTANT field, which is sane on the same driver - use it as a
+                // fallback whenever the legacy call fails the sanity check.
+                var fields = new nvmlFieldValue_t[] { new() { fieldId = NVML_FI_DEV_POWER_INSTANT } };
+                if (nvmlDeviceGetFieldValues(device, 1, fields) == NVML_SUCCESS
+                    && fields[0].nvmlReturn == NVML_SUCCESS)
+                {
+                    uint instMw = (uint)fields[0].value;
+                    if (instMw > 0 && instMw <= 200_000) return instMw / 1000f;
+                }
+
+                return null;
             }
             catch { return null; }
         }


### PR DESCRIPTION
Two related fixes for GPU readings on laptops where the dGPU power-gates (RTD3), found on a GU604 (RTX 4090 Laptop):

**1. Stale GPU temperature while the dGPU sleeps.**

`GetCurrentTemperature()` returns the cached `_lastTemp` whenever the GPU is asleep, so the main window and tray keep showing a frozen temperature indefinitely. It looks live and confuses users ("my GPU never cools below 45°" - it's just the last value from before the GPU went to sleep, displayed for hours). The `ShouldRefresh()` path also wakes the sleeping GPU periodically just to refresh that cache.

Now a temperature is only reported while the GPU is actually powered: the UI shows no GPU temperature when there is genuinely nothing to read, the fan logic no longer sees a phantom temperature from a chip that produces no heat, and the dGPU is left to sleep undisturbed (slightly better battery). A lightly-used GPU dips in and out of RTD3 for sub-second stretches between polls, so a 10 s grace keeps the last reading through those dips instead of blinking - it disappears only after a real sleep.

**2. NVML power reading is broken on mobile RTX 40, so the overlay never shows GPU watts.**

On this hardware `nvmlDeviceGetPowerUsage` returns a bogus scale (~593 000 mW at idle), which always fails the 200 W sanity check in `NvmlHelper.GetGpuPower()` - the OSD power column for the dGPU stays empty. nvidia-smi itself reads the `NVML_FI_DEV_POWER_INSTANT` field (186) instead, which reports sane values (21 959 mW idle, matching nvidia-smi output exactly). Added that as a fallback whenever the legacy call fails the sanity check; other GPUs keep using the old path.

Tested on GU604VY, driver 2026-07: overlay GPU power now populated, GPU temperature disappears ~10 s after the dGPU goes to sleep and returns on wake.