### PR TITLE
Add proxy settings and check-for-updates button

### DIFF
--- a/app/AutoUpdate/AutoUpdateControl.cs
+++ b/app/AutoUpdate/AutoUpdateControl.cs
@@ -37,6 +37,16 @@ namespace GHelper.AutoUpdate
             });
         }
 
+        public void CheckForAppUpdate()
+        {
+            lastUpdate = DateTimeOffset.Now.ToUnixTimeSeconds();
+            Task.Run(async () =>
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+                CheckForUpdatesAsync(manual: true);
+            });
+        }
+
         public void Update()
         {
             if (update)
@@ -63,7 +73,7 @@ namespace GHelper.AutoUpdate
             }
         }
 
-        async void CheckForUpdatesAsync(bool force = false)
+        async void CheckForUpdatesAsync(bool force = false, bool manual = false)
         {
 
             if (AppConfig.Is("skip_updates")) return;
@@ -71,9 +81,8 @@ namespace GHelper.AutoUpdate
             try
             {
 
-                using (var httpClient = new HttpClient())
+                using (var httpClient = ProxyHelper.CreateHttpClient("G-Helper App"))
                 {
-                    httpClient.DefaultRequestHeaders.Add("User-Agent", "G-Helper App");
                     var json = await httpClient.GetStringAsync("https://api.github.com/repos/seerge/g-helper/releases/latest");
                     var config = JsonSerializer.Deserialize<JsonElement>(json);
                     var tag = config.GetProperty("tag_name").ToString().Replace("v", "");
@@ -98,7 +107,11 @@ namespace GHelper.AutoUpdate
                     {
                         versionUrl = url;
                         update = true;
-                        settings.SetVersionLabel(Properties.Strings.DownloadUpdate + $": {appVersion.Major}.{appVersion.Minor}.{appVersion.Build} → {tag}", true);
+
+                        if (manual)
+                            settings.SetVersionLabel($"{Properties.Strings.VersionLabel}: {appVersion.Major}.{appVersion.Minor}.{appVersion.Build}→{tag}", true);
+                        else
+                            settings.SetVersionLabel(Properties.Strings.DownloadUpdate + $": {appVersion.Major}.{appVersion.Minor}.{appVersion.Build} → {tag}", true);
 
                         string[] args = Environment.GetCommandLineArgs();
                         if (force || args.Length > 1 && args[1] == "autoupdate")
@@ -126,6 +139,9 @@ namespace GHelper.AutoUpdate
                     else
                     {
                         Logger.WriteLine($"Latest version {appVersion}");
+
+                        if (manual)
+                            settings.SetVersionLabel($"{Properties.Strings.VersionLabel}: {appVersion.Major}.{appVersion.Minor}.{appVersion.Build}(已是最新)");
                     }
 
                 }
@@ -154,10 +170,9 @@ namespace GHelper.AutoUpdate
             string exeName = Path.GetFileName(exeLocation);
             string zipLocation = exeDir + "\\" + zipName;
 
-            using (HttpClient client = new HttpClient())
+            using (HttpClient client = ProxyHelper.CreateHttpClient("G-Helper App"))
             {
 
-                client.DefaultRequestHeaders.Add("User-Agent", "G-Helper App");
                 Logger.WriteLine(requestUri);
                 Logger.WriteLine(exeDir);
                 Logger.WriteLine(zipName);

--- a/app/Display/ColorProfileHelper.cs
+++ b/app/Display/ColorProfileHelper.cs
@@ -1,4 +1,4 @@
-﻿using GHelper.Helpers;
+using GHelper.Helpers;
 using System.IO.Compression;
 
 namespace GHelper.Display
@@ -680,7 +680,7 @@ namespace GHelper.Display
 
         static async Task DownloadAndExtractZip(string zipUrl, string extractPath)
         {
-            using (HttpClient client = new HttpClient())
+            using (HttpClient client = ProxyHelper.CreateHttpClient())
             {
                 try
                 {

--- a/app/Helpers/ProxyHelper.cs
+++ b/app/Helpers/ProxyHelper.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Net.Http;
+
+namespace GHelper.Helpers;
+
+public enum ProxyType
+{
+    None = 0,
+    Http = 1,
+    Socks5 = 2
+}
+
+public static class ProxyHelper
+{
+    public static ProxyType Type => (ProxyType)AppConfig.Get("proxy_type", 0);
+    public static string Host => AppConfig.GetString("proxy_host", "");
+    public static int Port => AppConfig.Get("proxy_port", 0);
+    public static string Username => AppConfig.GetString("proxy_username", "");
+    public static string Password => AppConfig.GetString("proxy_password", "");
+
+    public static bool IsConfigured() => Type != ProxyType.None && !string.IsNullOrEmpty(Host) && Port > 0;
+
+    public static void Save(ProxyType type, string host, int port, string username = "", string password = "")
+    {
+        AppConfig.Set("proxy_type", (int)type);
+        AppConfig.Set("proxy_host", host);
+        AppConfig.Set("proxy_port", port);
+        AppConfig.Set("proxy_username", username);
+        AppConfig.Set("proxy_password", password);
+    }
+
+    public static HttpClient CreateHttpClient(string? userAgent = null, bool autoDecompression = false)
+    {
+        HttpMessageHandler handler;
+
+        switch (Type)
+        {
+            case ProxyType.Http:
+                var socketsHandler = new SocketsHttpHandler
+                {
+                    Proxy = new WebProxy($"http://{Host}:{Port}"),
+                    UseProxy = true
+                };
+                if (autoDecompression)
+                    socketsHandler.AutomaticDecompression = DecompressionMethods.All;
+                handler = socketsHandler;
+                break;
+
+            case ProxyType.Socks5:
+                handler = new Socks5HttpMessageHandler(Host, Port,
+                    string.IsNullOrEmpty(Username) ? null : Username,
+                    string.IsNullOrEmpty(Password) ? null : Password);
+                break;
+
+            default:
+                var defaultHandler = new SocketsHttpHandler();
+                if (autoDecompression)
+                    defaultHandler.AutomaticDecompression = DecompressionMethods.All;
+                handler = defaultHandler;
+                break;
+        }
+
+        var client = new HttpClient(handler);
+
+        if (!string.IsNullOrEmpty(userAgent))
+        {
+            client.DefaultRequestHeaders.Add("User-Agent", userAgent);
+        }
+
+        if (autoDecompression && Type != ProxyType.Socks5)
+        {
+            client.DefaultRequestHeaders.AcceptEncoding.ParseAdd("gzip, deflate, br");
+        }
+
+        return client;
+    }
+
+    public static string GetDisplayText()
+    {
+        if (!IsConfigured()) return "";
+
+        string typeStr = Type == ProxyType.Http ? "HTTP" : "SOCKS5";
+        string authStr = string.IsNullOrEmpty(Username) ? "" : "(认证)";
+        return $"{typeStr} {Host}:{Port}{authStr}";
+    }
+}

--- a/app/Helpers/Socks5HttpHandler.cs
+++ b/app/Helpers/Socks5HttpHandler.cs
@@ -1,0 +1,343 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Text;
+
+namespace GHelper.Helpers;
+
+public class Socks5HttpMessageHandler : HttpMessageHandler
+{
+    private readonly string _proxyHost;
+    private readonly int _proxyPort;
+    private readonly string? _username;
+    private readonly string? _password;
+
+    public Socks5HttpMessageHandler(string proxyHost, int proxyPort, string? username = null, string? password = null)
+    {
+        _proxyHost = proxyHost;
+        _proxyPort = proxyPort;
+        _username = username;
+        _password = password;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var proxyEndPoint = new DnsEndPoint(_proxyHost, _proxyPort);
+        using var socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+        await socket.ConnectAsync(proxyEndPoint, cancellationToken);
+        using var stream = new NetworkStream(socket, ownsSocket: true);
+
+        await DoSocks5HandshakeAsync(stream, request, cancellationToken);
+
+        return await SendHttpRequestAsync(stream, request, cancellationToken);
+    }
+
+    private async Task DoSocks5HandshakeAsync(
+        Stream stream, HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        byte[] greeting;
+        bool hasAuth = !string.IsNullOrEmpty(_username);
+
+        if (hasAuth)
+            greeting = [0x05, 0x02, 0x00, 0x02];
+        else
+            greeting = [0x05, 0x01, 0x00];
+
+        await stream.WriteAsync(greeting, cancellationToken);
+
+        var response = new byte[2];
+        await ReadExactAsync(stream, response, cancellationToken);
+
+        if (response[0] != 0x05)
+            throw new InvalidOperationException($"SOCKS5: unexpected version {response[0]}");
+
+        byte selectedMethod = response[1];
+        if (selectedMethod == 0xFF)
+            throw new InvalidOperationException("SOCKS5: no acceptable authentication method");
+
+        if (selectedMethod == 0x02)
+        {
+            if (!hasAuth)
+                throw new InvalidOperationException("SOCKS5: authentication required");
+
+            byte[] authRequest = BuildAuthRequest(_username!, _password!);
+            await stream.WriteAsync(authRequest, cancellationToken);
+
+            var authResponse = new byte[2];
+            await ReadExactAsync(stream, authResponse, cancellationToken);
+
+            if (authResponse[1] != 0x00)
+                throw new InvalidOperationException("SOCKS5: authentication failed");
+        }
+        else if (selectedMethod != 0x00)
+        {
+            throw new InvalidOperationException($"SOCKS5: unsupported auth method {selectedMethod}");
+        }
+
+        string targetHost = request.RequestUri?.Host ?? "";
+        int targetPort = request.RequestUri?.Port ?? 80;
+        byte[] connectRequest = BuildConnectRequest(targetHost, targetPort);
+        await stream.WriteAsync(connectRequest, cancellationToken);
+
+        var connectResponseHeader = new byte[4];
+        await ReadExactAsync(stream, connectResponseHeader, cancellationToken);
+
+        if (connectResponseHeader[1] != 0x00)
+            throw new InvalidOperationException($"SOCKS5: connect failed (status {connectResponseHeader[1]})");
+
+        byte atyp = connectResponseHeader[3];
+        int addrLength = atyp switch
+        {
+            0x01 => 4,
+            0x03 => await ReadVarIntAsync(stream, cancellationToken),
+            0x04 => 16,
+            _ => throw new InvalidOperationException($"SOCKS5: unsupported address type {atyp}")
+        };
+
+        if (atyp == 0x03)
+        {
+            var domainBytes = new byte[addrLength];
+            await ReadExactAsync(stream, domainBytes, cancellationToken);
+        }
+        else
+        {
+            var addrBytes = new byte[addrLength];
+            await ReadExactAsync(stream, addrBytes, cancellationToken);
+        }
+
+        var portBytes = new byte[2];
+        await ReadExactAsync(stream, portBytes, cancellationToken);
+    }
+
+    private async Task<HttpResponseMessage> SendHttpRequestAsync(
+        Stream stream, HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        // Write request line
+        var uri = request.RequestUri;
+        string pathAndQuery = uri?.PathAndQuery ?? "/";
+        if (string.IsNullOrEmpty(pathAndQuery)) pathAndQuery = "/";
+
+        var requestLine = $"{request.Method.Method} {pathAndQuery} HTTP/{request.Version}";
+        byte[] requestLineBytes = Encoding.ASCII.GetBytes(requestLine + "\r\n");
+        await stream.WriteAsync(requestLineBytes, cancellationToken);
+
+        // Write headers
+        foreach (var header in request.Headers)
+        {
+            var headerLine = $"{header.Key}: {string.Join(", ", header.Value)}\r\n";
+            byte[] headerBytes = Encoding.ASCII.GetBytes(headerLine);
+            await stream.WriteAsync(headerBytes, cancellationToken);
+        }
+
+        if (request.Content != null)
+        {
+            foreach (var header in request.Content.Headers)
+            {
+                var headerLine = $"{header.Key}: {string.Join(", ", header.Value)}\r\n";
+                byte[] headerBytes = Encoding.ASCII.GetBytes(headerLine);
+                await stream.WriteAsync(headerBytes, cancellationToken);
+            }
+        }
+
+        // End of headers
+        await stream.WriteAsync(new byte[] { 0x0D, 0x0A }, cancellationToken);
+
+        // Write body
+        if (request.Content != null)
+        {
+            await request.Content.CopyToAsync(stream, cancellationToken);
+        }
+
+        // Read response
+        return await ReadHttpResponseAsync(stream, cancellationToken);
+    }
+
+    private async Task<HttpResponseMessage> ReadHttpResponseAsync(
+        Stream stream, CancellationToken cancellationToken)
+    {
+        var response = new HttpResponseMessage();
+
+        // Read status line
+        string statusLine = await ReadLineAsync(stream, cancellationToken);
+        if (string.IsNullOrEmpty(statusLine))
+            throw new InvalidOperationException("SOCKS5: empty response");
+
+        // Parse: HTTP/1.1 200 OK
+        var statusParts = statusLine.Split(' ', 3);
+        if (statusParts.Length < 2 || !int.TryParse(statusParts[1], out int statusCode))
+            throw new InvalidOperationException($"SOCKS5: invalid status line: {statusLine}");
+
+        response.StatusCode = (System.Net.HttpStatusCode)statusCode;
+        response.ReasonPhrase = statusParts.Length > 2 ? statusParts[2] : "";
+
+        string httpVersion = statusParts[0].Contains("1.0") ? "1.0" : "1.1";
+        response.Version = new Version(httpVersion);
+
+        // Read headers
+        var contentHeaders = new Dictionary<string, string>();
+        while (true)
+        {
+            string headerLine = await ReadLineAsync(stream, cancellationToken);
+            if (string.IsNullOrEmpty(headerLine))
+                break;
+
+            int colonIdx = headerLine.IndexOf(':');
+            if (colonIdx > 0)
+            {
+                string key = headerLine[..colonIdx].Trim();
+                string value = headerLine[(colonIdx + 1)..].Trim();
+
+                if (!response.Headers.TryAddWithoutValidation(key, value))
+                    contentHeaders[key] = value;
+            }
+        }
+
+        // Set content headers
+        foreach (var kvp in contentHeaders)
+        {
+            response.Content?.Headers.TryAddWithoutValidation(kvp.Key, kvp.Value);
+        }
+
+        // Read body
+        byte[] bodyBytes;
+        if (contentHeaders.TryGetValue("Content-Length", out string? contentLengthStr) &&
+            long.TryParse(contentLengthStr, out long contentLength))
+        {
+            bodyBytes = new byte[contentLength];
+            await ReadExactAsync(stream, bodyBytes, cancellationToken);
+        }
+        else if (contentHeaders.TryGetValue("Transfer-Encoding", out string? transferEncoding) &&
+                 transferEncoding.Equals("chunked", StringComparison.OrdinalIgnoreCase))
+        {
+            bodyBytes = await ReadChunkedBodyAsync(stream, cancellationToken);
+        }
+        else
+        {
+            // Read until connection close
+            using var ms = new MemoryStream();
+            await stream.CopyToAsync(ms, cancellationToken);
+            bodyBytes = ms.ToArray();
+        }
+
+        response.Content = new ByteArrayContent(bodyBytes);
+
+        // Apply content headers
+        foreach (var kvp in contentHeaders)
+        {
+            response.Content.Headers.TryAddWithoutValidation(kvp.Key, kvp.Value);
+        }
+
+        return response;
+    }
+
+    private async Task<byte[]> ReadChunkedBodyAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        using var ms = new MemoryStream();
+        while (true)
+        {
+            string sizeLine = await ReadLineAsync(stream, cancellationToken);
+            if (string.IsNullOrEmpty(sizeLine))
+                break;
+
+            int chunkSize = Convert.ToInt32(sizeLine.Trim(), 16);
+            if (chunkSize == 0)
+            {
+                // Read trailing CRLF
+                await ReadLineAsync(stream, cancellationToken);
+                break;
+            }
+
+            var chunk = new byte[chunkSize];
+            await ReadExactAsync(stream, chunk, cancellationToken);
+            ms.Write(chunk, 0, chunkSize);
+
+            // Read trailing CRLF
+            await ReadLineAsync(stream, cancellationToken);
+        }
+        return ms.ToArray();
+    }
+
+    private static async Task<string> ReadLineAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        using var ms = new MemoryStream();
+        int prevByte = -1;
+        while (true)
+        {
+            int b = await ReadByteAsync(stream, cancellationToken);
+            if (b == -1) break;
+
+            if (prevByte == '\r' && b == '\n')
+            {
+                // Remove the \r we added
+                var bytes = ms.ToArray();
+                if (bytes.Length > 0 && bytes[^1] == (byte)'\r')
+                    return Encoding.ASCII.GetString(bytes, 0, bytes.Length - 1);
+                return Encoding.ASCII.GetString(bytes);
+            }
+
+            ms.WriteByte((byte)b);
+            prevByte = b;
+        }
+
+        return Encoding.ASCII.GetString(ms.ToArray());
+    }
+
+    private static async Task<int> ReadByteAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[1];
+        int bytesRead = await stream.ReadAsync(buffer, cancellationToken);
+        return bytesRead == 0 ? -1 : buffer[0];
+    }
+
+    private static byte[] BuildAuthRequest(string username, string password)
+    {
+        byte[] userBytes = Encoding.UTF8.GetBytes(username);
+        byte[] passBytes = Encoding.UTF8.GetBytes(password);
+
+        var request = new byte[3 + userBytes.Length + passBytes.Length];
+        request[0] = 0x01;
+        request[1] = (byte)userBytes.Length;
+        Buffer.BlockCopy(userBytes, 0, request, 2, userBytes.Length);
+        request[2 + userBytes.Length] = (byte)passBytes.Length;
+        Buffer.BlockCopy(passBytes, 0, request, 3 + userBytes.Length, passBytes.Length);
+
+        return request;
+    }
+
+    private static byte[] BuildConnectRequest(string host, int port)
+    {
+        byte[] hostBytes = Encoding.UTF8.GetBytes(host);
+
+        var request = new byte[7 + hostBytes.Length];
+        request[0] = 0x05;
+        request[1] = 0x01;
+        request[2] = 0x00;
+        request[3] = 0x03;
+        request[4] = (byte)hostBytes.Length;
+        Buffer.BlockCopy(hostBytes, 0, request, 5, hostBytes.Length);
+        request[5 + hostBytes.Length] = (byte)(port >> 8);
+        request[6 + hostBytes.Length] = (byte)(port & 0xFF);
+
+        return request;
+    }
+
+    private static async Task ReadExactAsync(Stream stream, byte[] buffer, CancellationToken cancellationToken)
+    {
+        int totalRead = 0;
+        while (totalRead < buffer.Length)
+        {
+            int bytesRead = await stream.ReadAsync(buffer.AsMemory(totalRead, buffer.Length - totalRead), cancellationToken);
+            if (bytesRead == 0)
+                throw new InvalidOperationException("SOCKS5: connection closed unexpectedly");
+            totalRead += bytesRead;
+        }
+    }
+
+    private static async Task<int> ReadVarIntAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        var buffer = new byte[1];
+        await ReadExactAsync(stream, buffer, cancellationToken);
+        return buffer[0];
+    }
+}

--- a/app/ProxySettingsForm.Designer.cs
+++ b/app/ProxySettingsForm.Designer.cs
@@ -1,0 +1,243 @@
+namespace GHelper
+{
+    partial class ProxySettingsForm
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            labelProxyType = new Label();
+            comboProxyType = new UI.RComboBox();
+            labelHost = new Label();
+            textHost = new UI.RTextBox();
+            labelPort = new Label();
+            numericPort = new UI.RNumericUpDown();
+            labelUsername = new Label();
+            textUsername = new UI.RTextBox();
+            labelPassword = new Label();
+            textPassword = new UI.RTextBox();
+            buttonSave = new UI.RButton();
+            buttonCancel = new UI.RButton();
+            tableLayoutPanel = new TableLayoutPanel();
+            tableLayoutPanel.SuspendLayout();
+            SuspendLayout();
+            // 
+            // labelProxyType
+            // 
+            labelProxyType.AutoSize = true;
+            labelProxyType.Dock = DockStyle.Fill;
+            labelProxyType.Location = new Point(3, 0);
+            labelProxyType.Name = "labelProxyType";
+            labelProxyType.Size = new Size(64, 30);
+            labelProxyType.TabIndex = 0;
+            labelProxyType.Text = "代理类型";
+            labelProxyType.TextAlign = ContentAlignment.MiddleRight;
+            // 
+            // comboProxyType
+            // 
+            comboProxyType.Dock = DockStyle.Fill;
+            comboProxyType.DropDownStyle = ComboBoxStyle.DropDownList;
+            comboProxyType.FormattingEnabled = true;
+            comboProxyType.Items.AddRange(new object[] { "不使用代理", "HTTP 代理", "SOCKS5 代理" });
+            comboProxyType.Location = new Point(73, 3);
+            comboProxyType.Name = "comboProxyType";
+            comboProxyType.Size = new Size(214, 23);
+            comboProxyType.TabIndex = 1;
+            comboProxyType.SelectedIndexChanged += comboProxyType_SelectedIndexChanged;
+            // 
+            // labelHost
+            // 
+            labelHost.AutoSize = true;
+            labelHost.Dock = DockStyle.Fill;
+            labelHost.Location = new Point(3, 35);
+            labelHost.Name = "labelHost";
+            labelHost.Size = new Size(64, 28);
+            labelHost.TabIndex = 2;
+            labelHost.Text = "代理地址";
+            labelHost.TextAlign = ContentAlignment.MiddleRight;
+            // 
+            // textHost
+            // 
+            textHost.Dock = DockStyle.Fill;
+            textHost.Location = new Point(73, 38);
+            textHost.Name = "textHost";
+            textHost.PlaceholderText = "例如: 127.0.0.1";
+            textHost.Size = new Size(133, 23);
+            textHost.TabIndex = 3;
+            // 
+            // labelPort
+            // 
+            labelPort.AutoSize = true;
+            labelPort.Dock = DockStyle.Fill;
+            labelPort.Location = new Point(212, 35);
+            labelPort.Name = "labelPort";
+            labelPort.Size = new Size(37, 28);
+            labelPort.TabIndex = 4;
+            labelPort.Text = "端口";
+            labelPort.TextAlign = ContentAlignment.MiddleRight;
+            // 
+            // numericPort
+            // 
+            numericPort.Dock = DockStyle.Fill;
+            numericPort.Location = new Point(255, 38);
+            numericPort.Maximum = new decimal(new int[] { 65535, 0, 0, 0 });
+            numericPort.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            numericPort.Name = "numericPort";
+            numericPort.Size = new Size(32, 23);
+            numericPort.TabIndex = 5;
+            numericPort.Value = new decimal(new int[] { 7890, 0, 0, 0 });
+            // 
+            // labelUsername
+            // 
+            labelUsername.AutoSize = true;
+            labelUsername.Dock = DockStyle.Fill;
+            labelUsername.Location = new Point(3, 68);
+            labelUsername.Name = "labelUsername";
+            labelUsername.Size = new Size(64, 28);
+            labelUsername.TabIndex = 6;
+            labelUsername.Text = "用户名";
+            labelUsername.TextAlign = ContentAlignment.MiddleRight;
+            // 
+            // textUsername
+            // 
+            textUsername.Dock = DockStyle.Fill;
+            textUsername.Location = new Point(73, 71);
+            textUsername.Name = "textUsername";
+            textUsername.PlaceholderText = "可选";
+            textUsername.Size = new Size(133, 23);
+            textUsername.TabIndex = 7;
+            // 
+            // labelPassword
+            // 
+            labelPassword.AutoSize = true;
+            labelPassword.Dock = DockStyle.Fill;
+            labelPassword.Location = new Point(212, 68);
+            labelPassword.Name = "labelPassword";
+            labelPassword.Size = new Size(37, 28);
+            labelPassword.TabIndex = 8;
+            labelPassword.Text = "密码";
+            labelPassword.TextAlign = ContentAlignment.MiddleRight;
+            // 
+            // textPassword
+            // 
+            textPassword.Dock = DockStyle.Fill;
+            textPassword.Location = new Point(255, 71);
+            textPassword.Name = "textPassword";
+            textPassword.PlaceholderText = "可选";
+            textPassword.Size = new Size(32, 23);
+            textPassword.TabIndex = 9;
+            textPassword.UseSystemPasswordChar = true;
+            // 
+            // buttonSave
+            // 
+            buttonSave.Activated = false;
+            buttonSave.BackColor = SystemColors.ControlLight;
+            buttonSave.BorderColor = Color.Transparent;
+            buttonSave.BorderRadius = 2;
+            buttonSave.Dock = DockStyle.Top;
+            buttonSave.FlatStyle = FlatStyle.Flat;
+            buttonSave.Location = new Point(4, 1);
+            buttonSave.Margin = new Padding(4, 1, 4, 1);
+            buttonSave.Name = "buttonSave";
+            buttonSave.Secondary = false;
+            buttonSave.Size = new Size(82, 30);
+            buttonSave.TabIndex = 10;
+            buttonSave.Text = "保存";
+            buttonSave.UseVisualStyleBackColor = false;
+            buttonSave.Click += buttonSave_Click;
+            // 
+            // buttonCancel
+            // 
+            buttonCancel.Activated = false;
+            buttonCancel.BackColor = SystemColors.ControlLight;
+            buttonCancel.BorderColor = Color.Transparent;
+            buttonCancel.BorderRadius = 2;
+            buttonCancel.Dock = DockStyle.Top;
+            buttonCancel.FlatStyle = FlatStyle.Flat;
+            buttonCancel.Location = new Point(4, 1);
+            buttonCancel.Margin = new Padding(4, 1, 4, 1);
+            buttonCancel.Name = "buttonCancel";
+            buttonCancel.Secondary = true;
+            buttonCancel.Size = new Size(58, 30);
+            buttonCancel.TabIndex = 11;
+            buttonCancel.Text = "取消";
+            buttonCancel.UseVisualStyleBackColor = false;
+            buttonCancel.Click += buttonCancel_Click;
+            // 
+            // tableLayoutPanel
+            // 
+            tableLayoutPanel.ColumnCount = 4;
+            tableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 70F));
+            tableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            tableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 40F));
+            tableLayoutPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 50F));
+            tableLayoutPanel.Controls.Add(labelProxyType, 0, 0);
+            tableLayoutPanel.Controls.Add(comboProxyType, 1, 0);
+            tableLayoutPanel.Controls.Add(labelHost, 0, 1);
+            tableLayoutPanel.Controls.Add(textHost, 1, 1);
+            tableLayoutPanel.Controls.Add(labelPort, 2, 1);
+            tableLayoutPanel.Controls.Add(numericPort, 3, 1);
+            tableLayoutPanel.Controls.Add(labelUsername, 0, 2);
+            tableLayoutPanel.Controls.Add(textUsername, 1, 2);
+            tableLayoutPanel.Controls.Add(labelPassword, 2, 2);
+            tableLayoutPanel.Controls.Add(textPassword, 3, 2);
+            tableLayoutPanel.Controls.Add(buttonSave, 1, 3);
+            tableLayoutPanel.Controls.Add(buttonCancel, 3, 3);
+            tableLayoutPanel.Dock = DockStyle.Fill;
+            tableLayoutPanel.Location = new Point(12, 12);
+            tableLayoutPanel.Name = "tableLayoutPanel";
+            tableLayoutPanel.Padding = new Padding(0, 0, 0, 8);
+            tableLayoutPanel.RowCount = 4;
+            tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
+            tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
+            tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
+            tableLayoutPanel.RowStyles.Add(new RowStyle(SizeType.Absolute, 32F));
+            tableLayoutPanel.Size = new Size(290, 136);
+            tableLayoutPanel.TabIndex = 12;
+            // 
+            // ProxySettingsForm
+            // 
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(314, 145);
+            Controls.Add(tableLayoutPanel);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "ProxySettingsForm";
+            StartPosition = FormStartPosition.Manual;
+            Text = "代理设置";
+            Load += ProxySettingsForm_Load;
+            tableLayoutPanel.ResumeLayout(false);
+            tableLayoutPanel.PerformLayout();
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private Label labelProxyType;
+        private UI.RComboBox comboProxyType;
+        private Label labelHost;
+        private UI.RTextBox textHost;
+        private Label labelPort;
+        private UI.RNumericUpDown numericPort;
+        private Label labelUsername;
+        private UI.RTextBox textUsername;
+        private Label labelPassword;
+        private UI.RTextBox textPassword;
+        private UI.RButton buttonSave;
+        private UI.RButton buttonCancel;
+        private TableLayoutPanel tableLayoutPanel;
+    }
+}

--- a/app/ProxySettingsForm.cs
+++ b/app/ProxySettingsForm.cs
@@ -1,0 +1,105 @@
+using GHelper.Helpers;
+using GHelper.UI;
+
+namespace GHelper;
+
+public partial class ProxySettingsForm : RForm
+{
+    public ProxySettingsForm(Control? parent = null)
+    {
+        InitializeComponent();
+
+        if (parent != null)
+        {
+            var parentForm = parent.FindForm();
+            if (parentForm != null)
+            {
+                int x = parentForm.Left - Width - 10;
+                int y = parentForm.Top + (parentForm.Height - Height) / 2;
+
+                var screen = Screen.FromControl(parentForm);
+                if (x < screen.WorkingArea.Left)
+                    x = screen.WorkingArea.Left + 10;
+                if (y < screen.WorkingArea.Top)
+                    y = screen.WorkingArea.Top + 10;
+                if (y + Height > screen.WorkingArea.Bottom)
+                    y = screen.WorkingArea.Bottom - Height - 10;
+
+                Location = new Point(x, y);
+            }
+        }
+        else
+        {
+            StartPosition = FormStartPosition.CenterScreen;
+        }
+
+        InitTheme();
+    }
+
+    protected override void OnShown(EventArgs e)
+    {
+        base.OnShown(e);
+        ActiveControl = null;
+    }
+
+    private void ProxySettingsForm_Load(object? sender, EventArgs e)
+    {
+        comboProxyType.SelectedIndex = (int)ProxyHelper.Type;
+
+        textHost.Text = ProxyHelper.Host;
+        numericPort.Value = ProxyHelper.Port > 0 ? ProxyHelper.Port : 7890;
+        textUsername.Text = ProxyHelper.Username;
+        textPassword.Text = ProxyHelper.Password;
+
+        UpdateControlsState();
+    }
+
+    private void comboProxyType_SelectedIndexChanged(object? sender, EventArgs e)
+    {
+        UpdateControlsState();
+    }
+
+    private void UpdateControlsState()
+    {
+        bool enabled = comboProxyType.SelectedIndex > 0;
+        textHost.Enabled = enabled;
+        numericPort.Enabled = enabled;
+        textUsername.Enabled = enabled;
+        textPassword.Enabled = enabled;
+    }
+
+    private void buttonSave_Click(object? sender, EventArgs e)
+    {
+        var type = (ProxyType)comboProxyType.SelectedIndex;
+
+        if (type != ProxyType.None)
+        {
+            if (string.IsNullOrWhiteSpace(textHost.Text))
+            {
+                MessageBox.Show(this, "请输入代理地址", "错误", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                textHost.Focus();
+                return;
+            }
+
+            if (numericPort.Value < 1 || numericPort.Value > 65535)
+            {
+                MessageBox.Show(this, "请输入有效的端口号 (1-65535)", "错误", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                numericPort.Focus();
+                return;
+            }
+        }
+
+        ProxyHelper.Save(type, textHost.Text.Trim(), (int)numericPort.Value, textUsername.Text, textPassword.Text);
+
+        UpdatesController.RefreshHttpClient();
+
+        DialogResult = DialogResult.OK;
+        Close();
+    }
+
+    private void buttonCancel_Click(object? sender, EventArgs e)
+    {
+        DialogResult = DialogResult.Cancel;
+        Close();
+    }
+}

--- a/app/Settings.Designer.cs
+++ b/app/Settings.Designer.cs
@@ -1,4 +1,4 @@
-﻿using GHelper.UI;
+using GHelper.UI;
 
 namespace GHelper
 {
@@ -145,6 +145,7 @@ namespace GHelper
             buttonAmdOled = new RButton();
             buttonArmoury = new RButton();
             labelVersion = new Label();
+            linkLabelProxy = new LinkLabel();
             buttonHDRControl = new RButton();
             panelMatrix.SuspendLayout();
             panelMatrixAuto.SuspendLayout();
@@ -1987,6 +1988,7 @@ namespace GHelper
             panelVersion.Controls.Add(buttonEnergySaver);
             panelVersion.Controls.Add(buttonAmdOled);
             panelVersion.Controls.Add(buttonArmoury);
+            panelVersion.Controls.Add(linkLabelProxy);
             panelVersion.Controls.Add(labelVersion);
             panelVersion.Dock = DockStyle.Top;
             panelVersion.Location = new Point(11, 1837);
@@ -2076,6 +2078,26 @@ namespace GHelper
             labelVersion.TabIndex = 38;
             labelVersion.Text = "v.0";
             labelVersion.TextAlign = ContentAlignment.MiddleLeft;
+            // 
+            // linkLabelProxy
+            // 
+            linkLabelProxy.ActiveLinkColor = Color.FromArgb(255, 58, 174, 239);
+            linkLabelProxy.AutoSize = true;
+            linkLabelProxy.Cursor = Cursors.Hand;
+            linkLabelProxy.Dock = DockStyle.Left;
+            linkLabelProxy.Font = new Font("Segoe UI", 9F);
+            linkLabelProxy.LinkBehavior = LinkBehavior.NeverUnderline;
+            linkLabelProxy.LinkColor = Color.FromArgb(255, 128, 128, 128);
+            linkLabelProxy.Location = new Point(419, 5);
+            linkLabelProxy.Margin = new Padding(0);
+            linkLabelProxy.Name = "linkLabelProxy";
+            linkLabelProxy.Padding = new Padding(5, 0, 5, 0);
+            linkLabelProxy.Size = new Size(70, 40);
+            linkLabelProxy.TabIndex = 41;
+            linkLabelProxy.TabStop = true;
+            linkLabelProxy.Text = "代理设置";
+            linkLabelProxy.TextAlign = ContentAlignment.MiddleLeft;
+            linkLabelProxy.VisitedLinkColor = Color.FromArgb(255, 128, 128, 128);
             // 
             // buttonHDRControl
             // 
@@ -2301,6 +2323,7 @@ namespace GHelper
         private Label labelBacklight;
         private Panel panelVersion;
         private Label labelVersion;
+        private LinkLabel linkLabelProxy;
         private RBadgeButton buttonDonate;
         private RButton buttonEnergySaver;
         private RButton buttonAmdOled;

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -1,4 +1,4 @@
-﻿using GHelper.Ally;
+using GHelper.Ally;
 using GHelper.AnimeMatrix;
 using GHelper.AutoUpdate;
 using GHelper.Battery;
@@ -26,7 +26,7 @@ namespace GHelper
 
         public GPUModeControl gpuControl;
         public AllyControl allyControl;
-        AutoUpdateControl updateControl;
+        internal AutoUpdateControl updateControl;
 
         AsusMouseSettings? mouseSettings;
 
@@ -208,6 +208,9 @@ namespace GHelper
 
             labelVersion.Click += LabelVersion_Click;
             labelVersion.ForeColor = Color.FromArgb(128, Color.Gray);
+
+            linkLabelProxy.LinkClicked += LinkLabelProxy_LinkClicked;
+            UpdateProxyLabel();
 
             buttonOptimized.MouseMove += ButtonOptimized_MouseHover;
             buttonOptimized.MouseLeave += ButtonGPU_MouseLeave;
@@ -962,6 +965,22 @@ namespace GHelper
         private void LabelVersion_Click(object? sender, EventArgs e)
         {
             updateControl.Update();
+        }
+
+
+        private void LinkLabelProxy_LinkClicked(object? sender, LinkLabelLinkClickedEventArgs e)
+        {
+            using var form = new ProxySettingsForm(this);
+            if (form.ShowDialog() == DialogResult.OK)
+            {
+                UpdateProxyLabel();
+            }
+        }
+
+        public void UpdateProxyLabel()
+        {
+            string proxyText = ProxyHelper.IsConfigured() ? $"代理: {ProxyHelper.GetDisplayText()}" : "代理设置";
+            linkLabelProxy.Text = proxyText;
         }
 
 

--- a/app/Updates.Designer.cs
+++ b/app/Updates.Designer.cs
@@ -1,4 +1,4 @@
-﻿using GHelper.UI;
+using GHelper.UI;
 
 namespace GHelper
 {
@@ -51,6 +51,7 @@ namespace GHelper
             labelLegend = new Label();
             toolTip = new ToolTip(components);
             textSerial = new RTextBox();
+            buttonCheckAppUpdate = new RButton();
             ((System.ComponentModel.ISupportInitialize)pictureBios).BeginInit();
             panelBiosTitle.SuspendLayout();
             panelBios.SuspendLayout();
@@ -226,6 +227,7 @@ namespace GHelper
             tableLayoutLegend.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 28.2828274F));
             tableLayoutLegend.Controls.Add(labelSerialTitle, 0, 0);
             tableLayoutLegend.Controls.Add(textSerial, 1, 0);
+            tableLayoutLegend.Controls.Add(buttonCheckAppUpdate, 2, 0);
             tableLayoutLegend.Controls.Add(labelLegend, 0, 1);
             tableLayoutLegend.Controls.Add(labelLegendGray, 1, 1);
             tableLayoutLegend.Controls.Add(labelLegendGreen, 2, 1);
@@ -320,6 +322,25 @@ namespace GHelper
             textSerial.Size = new Size(323, 39);
             textSerial.TabIndex = 6;
             // 
+            // buttonCheckAppUpdate
+            // 
+            buttonCheckAppUpdate.Activated = false;
+            buttonCheckAppUpdate.BackColor = SystemColors.ControlLight;
+            buttonCheckAppUpdate.BorderColor = Color.Transparent;
+            buttonCheckAppUpdate.BorderRadius = 5;
+            buttonCheckAppUpdate.Dock = DockStyle.Top;
+            buttonCheckAppUpdate.FlatAppearance.BorderSize = 0;
+            buttonCheckAppUpdate.FlatStyle = FlatStyle.Flat;
+            buttonCheckAppUpdate.Font = new Font("Segoe UI", 9F);
+            buttonCheckAppUpdate.Location = new Point(562, 68);
+            buttonCheckAppUpdate.Margin = new Padding(10, 8, 10, 8);
+            buttonCheckAppUpdate.Name = "buttonCheckAppUpdate";
+            buttonCheckAppUpdate.Secondary = true;
+            buttonCheckAppUpdate.Size = new Size(323, 39);
+            buttonCheckAppUpdate.TabIndex = 7;
+            buttonCheckAppUpdate.Text = "程序检查更新";
+            buttonCheckAppUpdate.UseVisualStyleBackColor = false;
+            // 
             // Updates
             // 
             AutoScaleDimensions = new SizeF(192F, 192F);
@@ -376,5 +397,6 @@ namespace GHelper
         private ToolTip toolTip;
         private Label labelSerialTitle;
         private RTextBox textSerial;
+        private RButton buttonCheckAppUpdate;
     }
 }

--- a/app/Updates.cs
+++ b/app/Updates.cs
@@ -149,6 +149,7 @@ namespace GHelper
             _font = new Font(Font, FontStyle.Underline);
 
             buttonRefresh.Click += ButtonRefresh_Click;
+            buttonCheckAppUpdate.Click += ButtonCheckAppUpdate_Click;
             Shown += Updates_Shown;
             Resize += (s, e) => AlignLabelUpdates();
 
@@ -165,6 +166,11 @@ namespace GHelper
         private void ButtonRefresh_Click(object? sender, EventArgs e)
         {
             LoadUpdates();
+        }
+
+        private void ButtonCheckAppUpdate_Click(object? sender, EventArgs e)
+        {
+            Program.settingsForm.updateControl.CheckForAppUpdate();
         }
 
         private void AlignLabelUpdates()

--- a/app/UpdatesController.cs
+++ b/app/UpdatesController.cs
@@ -38,14 +38,17 @@ namespace GHelper
 
         static readonly string[] SkipList = { "Armoury Crate & Aura Creator Installer", "MyASUS", "ASUS Smart Display Control", "Aura Wallpaper", "Virtual Pet", "Virtual Pet- Ultimate Edition", "ROG Font V1.5", "Armoury Crate Control Interface", "Virtual Assistant" };
 
-        static readonly HttpClient _httpClient = CreateHttpClient();
+        static HttpClient _httpClient = CreateHttpClient();
 
         static HttpClient CreateHttpClient()
         {
-            var client = new HttpClient(new HttpClientHandler { AutomaticDecompression = DecompressionMethods.All });
-            client.DefaultRequestHeaders.AcceptEncoding.ParseAdd("gzip, deflate, br");
-            client.DefaultRequestHeaders.Add("User-Agent", "C# App");
-            return client;
+            return ProxyHelper.CreateHttpClient("C# App", autoDecompression: true);
+        }
+
+        public static void RefreshHttpClient()
+        {
+            _httpClient?.Dispose();
+            _httpClient = CreateHttpClient();
         }
 
         public async Task<List<DriverUpdate>> FetchUpdates(string url, CancellationToken token = default)


### PR DESCRIPTION
Add check-for-updates button in updates tab to manually check updates. Add proxy settings label that opens a proxy configuration window. Support HTTP and SOCKS5 proxy configuration with authentication. Implement Socks5HttpMessageHandler for SOCKS5 proxy support. Centralize proxy management via ProxyHelper class. Update all HttpClient creation points to use ProxyHelper.