### PR TITLE
Drag all fan curve points horizontally too when holding Shift

### DIFF
--- a/app/Fans.cs
+++ b/app/Fans.cs
@@ -1567,12 +1567,14 @@ namespace GHelper
                             dx = Math.Max(minX, Math.Min(maxX, dx));
                         }
 
-                        curPoint.XValue = dx;
-
                         if (Control.ModifierKeys == Keys.Shift)
-                            AdjustAll(0, deltaY, series);
+                        {
+                            // clamped dots are locked to their 10-degree slots, so the group moves vertically only
+                            AdjustAll(clampFanDots ? 0 : deltaX, deltaY, series);
+                        }
                         else
                         {
+                            curPoint.XValue = dx;
                             curPoint.YValues[0] = dy;
                             AdjustAllLevels(curIndex, dx, dy, series);
                         }


### PR DESCRIPTION
Holding Shift while dragging a fan curve point is supposed to move all points together, but it only worked vertically: AdjustAll was always called with a zero horizontal delta, and the grabbed point moved horizontally on its own.

This passes the horizontal delta as well, so with Shift the whole curve follows the mouse on both axes. The grabbed point moves together with the rest instead of separately. At the scale edges points clamp one by one, same as the vertical drag has always done at 0/100%.

With Clamp fan dots enabled the group still moves vertically only, since every dot is locked to its 10 degree slot.

Tested on a GU604VY.
