### PR TITLE
Decouple screen refresh from GPU eco/Nvidia service pipeline

### DIFF
--- a/app/Gpu/GPUModeControl.cs
+++ b/app/Gpu/GPUModeControl.cs
@@ -166,65 +166,98 @@ namespace GHelper.Gpu
 
             settings.LockGPUModes();
 
-            Task.Run(async () =>
+            // Screen refresh only depends on power line status, not on GPU/eco state, so it
+            // runs as an independent sibling task instead of being sequenced behind, or bolted
+            // onto, the GPU/nvidia work below. Called directly (not via settings.Invoke) since
+            // ChangeDisplaySettingsEx is a slow blocking OS call - InitScreen() already
+            // marshals its own narrow UI update internally, so forcing the whole call onto the
+            // UI thread here would freeze the window for the duration of the mode change.
+            Task.Run(() => ScreenControl.AutoScreen());
+            Task.Run(() => RunGPUEcoSequence(eco));
+        }
+
+        private async Task RunGPUEcoSequence(int eco)
+        {
+            int status = 1;
+
+            Program.modeControl.WaitForApply();
+
+            if (eco == 1)
+            {
+                HardwareControl.KillGPUApps();
+                HardwareControl.DisposeGpuControl();
+                // Stop-Service blocks until the service has actually stopped, so this line
+                // itself is the "wait" - no extra guessed delay needed after it.
+                if (AppConfig.IsNVPlatform()) NvidiaGpuControl.StopNVService();
+            }
+
+            Logger.WriteLine($"Running eco command {eco}");
+
+            try
             {
 
-                int status = 1;
+                status = Program.acpi.SetGPUEco(eco);
 
-                Program.modeControl.WaitForApply();
+                // Wait for the ACPI eco flag to actually reflect the change instead of
+                // guessing how long that takes. refresh_delay is now only the safety-net
+                // timeout, not the wait itself.
+                await AsyncHelper.PollUntilAsync(
+                    () => Program.acpi.DeviceGet(AsusACPI.GPUEco) == eco,
+                    intervalMs: 100,
+                    timeoutMs: AppConfig.Get("refresh_delay", 500));
 
-                if (eco == 1)
+                settings.Invoke(delegate
                 {
-                    HardwareControl.KillGPUApps();
-                    HardwareControl.DisposeGpuControl();
-                    if (AppConfig.IsNVPlatform()) NvidiaGpuControl.StopNVService();
-                }
+                    InitGPUMode();
+                });
 
-                Logger.WriteLine($"Running eco command {eco}");
-
-                try
+                if (eco == 0)
                 {
-
-                    status = Program.acpi.SetGPUEco(eco);
-                    await Task.Delay(TimeSpan.FromMilliseconds(AppConfig.Get("refresh_delay", 500)));
-
-                    settings.Invoke(delegate
+                    if (AppConfig.IsNVPlatform() || nvRestartPending)
                     {
-                        InitGPUMode();
-                        ScreenControl.AutoScreen();
-                    });
+                        settings.LockGPUModes(Properties.Strings.RestartingNVServices);
 
-                    if (eco == 0)
-                    {
-                        if (AppConfig.IsNVPlatform() || nvRestartPending)
-                        {
-                            settings.LockGPUModes(Properties.Strings.RestartingNVServices);
-                            await Task.Delay(TimeSpan.FromMilliseconds(AppConfig.Get("nv_delay", 5000)));
-                            if (AppConfig.IsNVPlatform()) NvidiaGpuControl.RestartNVService();
-                            else NvidiaGpuControl.RestartNvContainer();
-                            nvRestartPending = false;
-                            settings.Invoke(delegate { InitGPUMode(); });
-                            await Task.Delay(TimeSpan.FromMilliseconds(1000));
-                        }
+                        // Restart-Service blocks until it has actually restarted; on failure
+                        // (GPU/PCIe link not re-enumerated yet) it throws quickly, so retry
+                        // with backoff instead of a single flat wait-then-try.
+                        bool restarted = await AsyncHelper.PollUntilAsync(
+                            () =>
+                            {
+                                try
+                                {
+                                    if (AppConfig.IsNVPlatform()) NvidiaGpuControl.RestartNVService();
+                                    else NvidiaGpuControl.RestartNvContainer();
+                                    return true;
+                                }
+                                catch (Exception ex)
+                                {
+                                    Logger.WriteLine("NV service restart attempt failed: " + ex.Message);
+                                    return false;
+                                }
+                            },
+                            intervalMs: 500,
+                            timeoutMs: AppConfig.Get("nv_delay", 5000));
 
-                        await HardwareControl.RecreateGpuControlWithRetry(3, 2);
-                        Program.modeControl.SetGPUClocks(false);
+                        if (!restarted) Logger.WriteLine("NV service did not restart within timeout");
+
+                        nvRestartPending = false;
+                        settings.Invoke(delegate { InitGPUMode(); });
                     }
 
-                    if (AppConfig.IsModeReapplyRequired())
-                    {
-                        await Task.Delay(TimeSpan.FromMilliseconds(3000));
-                        Program.modeControl.AutoPerformance();
-                    }
+                    await HardwareControl.RecreateGpuControlWithRetry(3, 2);
+                    Program.modeControl.SetGPUClocks(false);
                 }
-                catch (Exception ex)
+
+                if (AppConfig.IsModeReapplyRequired())
                 {
-                    Logger.WriteLine("Error setting GPU Eco: " + ex.Message);
+                    await Task.Delay(TimeSpan.FromMilliseconds(3000));
+                    Program.modeControl.AutoPerformance();
                 }
-
-            });
-
-
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteLine("Error setting GPU Eco: " + ex.Message);
+            }
         }
 
         public static bool IsPlugged() =>

--- a/app/Helpers/AsyncHelper.cs
+++ b/app/Helpers/AsyncHelper.cs
@@ -1,0 +1,20 @@
+namespace GHelper.Helpers
+{
+    public static class AsyncHelper
+    {
+        // Polls `condition` at `intervalMs` until it's true, instead of guessing a fixed delay.
+        // Always bounded by `timeoutMs` as a safety net for hardware that never reports the expected state.
+        public static async Task<bool> PollUntilAsync(Func<bool> condition, int intervalMs, int timeoutMs)
+        {
+            var deadline = Environment.TickCount64 + timeoutMs;
+
+            while (Environment.TickCount64 < deadline)
+            {
+                if (condition()) return true;
+                await Task.Delay(intervalMs);
+            }
+
+            return condition();
+        }
+    }
+}

--- a/app/Helpers/ProcessHelper.cs
+++ b/app/Helpers/ProcessHelper.cs
@@ -74,12 +74,12 @@ namespace GHelper.Helpers
 
                     if (failed.Count > 0)
                     {
-                        Thread.Sleep(2000);
-
                         foreach (var p in failed)
                         {
                             bool stillAlive;
-                            try { stillAlive = !p.HasExited; }
+                            // Wait for the actual exit signal instead of a blind sleep - returns
+                            // as soon as the process exits, 2000ms is only the fallback timeout.
+                            try { stillAlive = !p.WaitForExit(2000); }
                             catch { stillAlive = true; }
 
                             if (stillAlive)

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -366,7 +366,11 @@ namespace GHelper
 
         public static PowerSource currentSource = PowerSource.Battery;
         private static PowerLineStatus lastLineStatus = SystemInformation.PowerStatus.PowerLineStatus;
-        private static readonly System.Timers.Timer powerSettleTimer = new() { AutoReset = false };
+
+        // Short, fixed debounce: only coalesces the burst of duplicate OS/WMI events that
+        // fire for a single physical plug/unplug. Not a hardware settle wait.
+        private static readonly System.Timers.Timer powerSettleTimer = new(100) { AutoReset = false };
+        private static int powerSettleGeneration;
 
         public static PowerSource ReadPowerSource()
         {
@@ -388,14 +392,38 @@ namespace GHelper
         public static void SchedulePowerCheck()
         {
             if (AppConfig.Is("disable_power_event")) return;
-            powerSettleTimer.Interval = Math.Max(AppConfig.Get("charger_delay"), 2000);
             powerSettleTimer.Stop();
             powerSettleTimer.Start();
         }
 
         private static void OnPowerSettled(object? sender, System.Timers.ElapsedEventArgs e)
         {
-            PowerSource source = ReadPowerSource();
+            _ = SettlePowerSourceAsync();
+        }
+
+        // Instead of guessing how long the ACPI ChargerMode register takes to update, poll it
+        // until two consecutive reads agree (i.e. it has actually stopped changing), capped by
+        // charger_delay as a safety-net timeout rather than a guaranteed wait.
+        private static async Task SettlePowerSourceAsync()
+        {
+            int generation = System.Threading.Interlocked.Increment(ref powerSettleGeneration);
+
+            PowerSource? lastReading = null;
+            await AsyncHelper.PollUntilAsync(
+                () =>
+                {
+                    PowerSource reading = ReadPowerSource();
+                    bool stable = lastReading == reading;
+                    lastReading = reading;
+                    return stable;
+                },
+                intervalMs: 100,
+                timeoutMs: Math.Max(AppConfig.Get("charger_delay"), 2000));
+
+            // A newer power event superseded this one while we were polling - let that one win.
+            if (generation != powerSettleGeneration) return;
+
+            PowerSource source = lastReading ?? ReadPowerSource();
             if (source == currentSource) return;
 
             Logger.WriteLine($"Power source: {currentSource} -> {source}");


### PR DESCRIPTION
Screen refresh rate previously waited behind KillGPUApps/StopNVService and the fixed nv_delay before applying, since AutoScreen() only needs PowerLineStatus. It now runs as an independent task instead of being sequenced behind, or invoked onto, the GPU/eco work.

Also replaces several fixed guessed-delay waits with condition polling via a new AsyncHelper.PollUntilAsync: the ACPI eco flag apply, the Nvidia service restart (now retried with backoff instead of a flat 5s wait), and the charger power-source debounce (now polls until the ACPI ChargerMode register stabilizes instead of blindly waiting the full charger_delay). ProcessHelper's duplicate-instance kill also uses Process.WaitForExit instead of a flat Thread.Sleep.