### PR TITLE
Add null check for registry keys before writing values

### DIFF
--- a/app/Battery/BatteryControl.cs
+++ b/app/Battery/BatteryControl.cs
@@ -54,6 +54,11 @@ namespace GHelper.Battery
             try
             {
                 using var key = Registry.LocalMachine.OpenSubKey(keyPath, writable: true);
+                if (key is null)
+                {
+                    Logger.WriteLine("Failed to set ChargingRate: registry key not found");
+                    return;
+                }
                 key.SetValue("ChargingRate", value, RegistryValueKind.DWord);
             }
             catch (Exception ex)

--- a/app/Display/ScreenControl.cs
+++ b/app/Display/ScreenControl.cs
@@ -45,6 +45,11 @@ namespace GHelper.Display
             try
             {
                 using var key = Registry.LocalMachine.OpenSubKey(keyPath, writable: true);
+                if (key is null)
+                {
+                    Logger.WriteLine("Failed to set RefreshFlag: registry key not found");
+                    return;
+                }
                 key.SetValue("RefreshFlag", value, RegistryValueKind.DWord);
             }
             catch (Exception ex)


### PR DESCRIPTION
## Problem

Two methods open HKLM registry keys for writing without checking whether `OpenSubKey` returned a key:

- `app/Battery/BatteryControl.cs` — `SetAsusChargeLimit()`
- `app/Display/ScreenControl.cs` — `SetAsusRefreshFlag()`

`OpenSubKey` returns `null` (it does not throw) when the key is missing. The subsequent `key.SetValue(...)` then throws a `NullReferenceException`, and the existing `catch` logs:

```
Failed to set ChargingRate: Object reference not set to an instance of an object.
```

This hides the real cause — the ASUS registry key not being present, which is common for G-Helper's target audience (people who uninstall Armoury Crate / ASUS System Control Interface).

## Solution

Null-check the returned key and log a meaningful message instead, following the existing pattern in `app/Helpers/Keystone.cs`:

```csharp
if (key is null)
{
    Logger.WriteLine("Failed to set ChargingRate: registry key not found");
    return;
}
```

Applied to both sites.

## Verification

`dotnet build app/GHelper.csproj` — 0 warnings, 0 errors.

Co-authored-by: FirmamentalSpring <287222957+FirmaSpring@users.noreply.github.com>
