### PR TITLE
Skip charge-limit task creation when not elevated

### DIFF
--- a/app/Helpers/Startup.cs
+++ b/app/Helpers/Startup.cs
@@ -142,6 +142,7 @@ public class Startup
     {
 
         if (strExeFilePath is null) return;
+        if (!ProcessHelper.IsUserAdministrator()) return;
 
         using (TaskDefinition td = TaskService.Instance.NewTask())
         {


### PR DESCRIPTION
@seerge found this while dogfooding on my own G614PR - `log.txt` had the same line repeating on every single launch for days:

```
Can't create a charge limit task: Access is denied. (0x80070005 (E_ACCESSDENIED))
```

`ScheduleCharge()` registers a SYSTEM-level scheduled task, which needs an elevated process. `StartupCheck()` calls it on every normal launch with no admin check, so on a non-elevated launch it fails every time and just retries forever since the task never actually gets created.

Fix is a one-line guard in `ScheduleCharge()` itself so it'\''s a no-op instead of a permanent failure loop.

Tested: built and ran locally, confirmed the log spam stops on a non-elevated launch and the task still gets created fine when running elevated.