### PR TITLE
Fix off-by-one bounds check in AsusMouse.SetProfile

### DIFF
--- a/app/Peripherals/Mouse/AsusMouse.cs
+++ b/app/Peripherals/Mouse/AsusMouse.cs
@@ -929,7 +929,7 @@ namespace GHelper.Peripherals.Mouse
                 return;
             }
 
-            if (profile > ProfileCount() || profile < 0)
+            if (profile >= ProfileCount() || profile < 0)
             {
                 Logger.WriteLine(GetDisplayName() + ": Profile:" + profile + " is invalid.");
                 return;


### PR DESCRIPTION
@seerge `SetProfile` rejects `profile > ProfileCount()`, but profiles are 0-indexed (see the caller in `AsusMouseSettings.cs` using `comboProfile.SelectedIndex`, and the equivalent check in the keyboard path which already uses `>=`). That lets `profile == ProfileCount()` - one past the last valid index - through validation and into `GetUpdateProfilePacket` and `this.Profile`.

Not reachable through the current combo-box UI since `SelectedIndex` never reaches the boundary value, but any other caller passing it would silently send an invalid profile index to the device. One-character fix: `>` to `>=`.