### PR TITLE
Wire up OnExit cleanup handler

### DIFF
--- a/app/Program.cs
+++ b/app/Program.cs
@@ -180,6 +180,7 @@ namespace GHelper
             unRegPowerNotifyEnergy = NativeMethods.RegisterPowerSettingNotification(settingsForm.Handle, PowerSettingGuid.EnergySaverStatus, NativeMethods.DEVICE_NOTIFY_WINDOW_HANDLE);
             unRegSuspendResume = NativeMethods.RegisterSuspendResumeNotification(settingsForm.Handle, NativeMethods.DEVICE_NOTIFY_WINDOW_HANDLE);
 
+            Application.ApplicationExit += OnExit;
 
             Task task = Task.Run(() =>
             {


### PR DESCRIPTION
@seerge `Program.OnExit` (tray icon disposal, unregistering power-setting/device-change notifications) is never subscribed to anything - no match for `ApplicationExit` anywhere in the repo, and every quit path (`ButtonQuit_Click`, the two `Application.Exit()` calls in `Main`) calls `Application.Exit()` directly, skipping it entirely. So the cleanup it'\''s meant to do has never actually run.

Fix: subscribe `Application.ApplicationExit += OnExit;` in `Main()` after the fields it references (`clamshellControl`, the `unRegPowerNotify*` handles) are initialized, so it fires on every exit path uniformly.

Minor impact since process exit reclaims OS handles anyway, but it's dead code doing exactly nothing it was written for.