### PR TITLE
Fixed AutoUpdateControl not actually updating. 

### DIFF
--- a/app/AutoUpdate/AutoUpdateControl.cs
+++ b/app/AutoUpdate/AutoUpdateControl.cs
@@ -1,4 +1,4 @@
-﻿using GHelper.Helpers;
+using GHelper.Helpers;
 using System.Diagnostics;
 using System.Net.Http;
 using System.Reflection;
@@ -94,7 +94,11 @@ namespace GHelper.AutoUpdate
                     var appVersion = new Version(Assembly.GetExecutingAssembly().GetName().Version.ToString());
                     //appVersion = new Version("0.50.0.0"); 
 
+#if DEBUG
+                    if (Debugger.IsAttached || gitVersion.CompareTo(appVersion) > 0)
+#else
                     if (gitVersion.CompareTo(appVersion) > 0)
+#endif
                     {
                         versionUrl = url;
                         update = true;
@@ -139,7 +143,7 @@ namespace GHelper.AutoUpdate
 
         public static string EscapeString(string input)
         {
-            return Regex.Replace(Regex.Replace(input, @"\[|\]", "`$0"), @"\'", "''");
+            return Regex.Replace(input, @"([\[\]\*\?])", "`$1");
         }
 
         async void AutoUpdate(string requestUri)
@@ -183,26 +187,25 @@ namespace GHelper.AutoUpdate
                     return;
                 }
 
-                string command = $"$ErrorActionPreference = \"Stop\"; Set-Location -Path '{EscapeString(exeDir)}'; Wait-Process -Name \"GHelper\"; Expand-Archive \"{zipName}\" -DestinationPath . -Force; Remove-Item \"{zipName}\" -Force; \".\\{exeName}\"; ";
+                var processName = Process.GetCurrentProcess().ProcessName;
+
+                var command = $"$ErrorActionPreference = 'Stop'; Set-Location -Path '{EscapeString(exeDir)}'; Get-Process -Name '{processName}' | Stop-Process -Force; Expand-Archive '{zipName}' -OutputPath . -Force; Remove-Item '{zipName}' -Force; .\\{exeName};";
                 Logger.WriteLine(command);
 
                 try
                 {
                     var cmd = new Process();
-                    cmd.StartInfo.WorkingDirectory = exeDir;
                     cmd.StartInfo.UseShellExecute = false;
                     cmd.StartInfo.CreateNoWindow = true;
                     cmd.StartInfo.FileName = "powershell";
                     cmd.StartInfo.Arguments = command;
-                    if (ProcessHelper.IsUserAdministrator()) cmd.StartInfo.Verb = "runas";
+                    if (!ProcessHelper.IsUserAdministrator()) cmd.StartInfo.Verb = "runas";
                     cmd.Start();
                 }
                 catch (Exception ex)
                 {
                     Logger.WriteLine(ex.Message);
                 }
-
-                Application.Exit();
             }
 
         }


### PR DESCRIPTION
Also fixed/simplified the escape RegEx and added conditional compilation to make testing updates easier by checking for a debugger attached when built in DEBUG mode. The Admin check was not actually setting the verb when it was needed.

There were several issues though including the Windows PowerShell `Expand-Archive` parameter not being correct (`-DestinationPath` is the parameter name in [pwsh](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.archive/expand-archive?view=powershell-7.6)) and then there was a race condition with the `powershell.exe` process and the application exiting after launching it so I just let the `powershell.exe` forcibly close the application.

Sorry this auto updating not working has been driving me crazy since I first downloaded this. Figured I would just fix it.