### PR TITLE
Fixed state-persistence when switching from Ultimate to Eco GPU Mode, Added ProcessHelper.RunSilent, Small consistency adjustments

### DIFF
--- a/app/Gpu/GPUModeControl.cs
+++ b/app/Gpu/GPUModeControl.cs
@@ -15,7 +15,6 @@ namespace GHelper.Gpu
 
         static bool nvRestartPending;
 
-
         public GPUModeControl(SettingsForm settingsForm)
         {
             settings = settingsForm;
@@ -72,7 +71,6 @@ namespace GHelper.Gpu
             Aura.CustomRGB.ApplyGPUColor(gpuMode);
 
             CheckGpuError();
-
         }
 
 
@@ -92,16 +90,17 @@ namespace GHelper.Gpu
             var restart = false;
             var changed = false;
 
-            int status;
 
             if (CurrentGPU == AsusACPI.GPUModeUltimate)
             {
                 DialogResult dialogResult = settings.ShowMessage(Properties.Strings.AlertUltimateOff, Properties.Strings.AlertUltimateTitle, MessageBoxButtons.YesNo);
                 if (dialogResult == DialogResult.Yes)
                 {
-                    status = Program.acpi.DeviceSet(AsusACPI.GPUMux, 1, "GPUMux");
+                    Program.acpi.DeviceSet(AsusACPI.GPUMux, 1, "GPUMux");
                     restart = true;
                     changed = true;
+
+                    if (GPUMode == AsusACPI.GPUModeEco) Startup.ScheduleEcoMode();
                 }
             }
             else if (GPUMode == AsusACPI.GPUModeUltimate)
@@ -127,7 +126,7 @@ namespace GHelper.Gpu
                         return;
                     }
 
-                    status = Program.acpi.DeviceSet(AsusACPI.GPUMux, 0, "GPUMux");
+                    Program.acpi.DeviceSet(AsusACPI.GPUMux, 0, "GPUMux");
                     restart = true;
                     changed = true;
                 }
@@ -154,9 +153,8 @@ namespace GHelper.Gpu
             if (restart)
             {
                 settings.VisualiseGPUMode();
-                Process.Start("shutdown", "/r /t 1");
+                ProcessHelper.RunSilent("shutdown", "/r /t 1");
             }
-
         }
 
 
@@ -228,8 +226,6 @@ namespace GHelper.Gpu
                 }
 
             });
-
-
         }
 
         public static bool IsPlugged() =>
@@ -295,7 +291,6 @@ namespace GHelper.Gpu
             }
 
             return false;
-
         }
 
 

--- a/app/Helpers/ProcessHelper.cs
+++ b/app/Helpers/ProcessHelper.cs
@@ -247,6 +247,26 @@ namespace GHelper.Helpers
             return result;
         }
 
+        public static void RunSilent(string cmd, string args, string? directory = null)
+        {
+            try
+            {
+                using var process = new Process();
+                process.StartInfo.UseShellExecute = false;
+                process.StartInfo.CreateNoWindow = true;
+                process.StartInfo.RedirectStandardOutput = true;
+                process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+                process.StartInfo.FileName = cmd;
+                process.StartInfo.Arguments = args;
+                if (directory != null) process.StartInfo.WorkingDirectory = directory;
+                process.Start();
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteLine(ex.ToString());
+            }
+        } 
+
         public static void SetPriority(ProcessPriorityClass priorityClass = ProcessPriorityClass.Normal)
         {
             try

--- a/app/Helpers/Startup.cs
+++ b/app/Helpers/Startup.cs
@@ -1,4 +1,4 @@
-﻿using GHelper.Helpers;
+﻿ using GHelper.Helpers;
 using Microsoft.Win32.TaskScheduler;
 using System.Diagnostics;
 using System.Reflection;
@@ -9,6 +9,7 @@ public class Startup
 
     static string taskName = "GHelper";
     static string chargeTaskName = taskName + "Charge";
+    static string ecoTaskName = taskName + "GPUEco";
     static string strExeFilePath = Application.ExecutablePath.Trim();
     static string userTaskName = taskName + "_" + WindowsIdentity.GetCurrent().User.Value;
 
@@ -51,7 +52,7 @@ public class Startup
     {
         if (ProcessHelper.IsUserAdministrator() && IsScheduled())
         {
-            UnSchedule();
+            Unschedule();
             Schedule();
         }
     }
@@ -108,7 +109,7 @@ public class Startup
                             return;
                         }
                         Logger.WriteLine("Rescheduling to: " + strExeFilePath);
-                        UnSchedule();
+                        Unschedule();
                         Schedule();
                     }
                 }
@@ -119,21 +120,6 @@ public class Startup
 
                 if (taskService.RootFolder.AllTasks.FirstOrDefault(t => t.Name == chargeTaskName) == null) ScheduleCharge();
 
-            }
-        }
-    }
-
-    public static void UnscheduleCharge()
-    {
-        using (TaskService taskService = new TaskService())
-        {
-            try
-            {
-                taskService.RootFolder.DeleteTask(chargeTaskName);
-            }
-            catch (Exception e)
-            {
-                Logger.WriteLine("Can't remove charge limit task: " + e.Message);
             }
         }
     }
@@ -174,6 +160,68 @@ public class Startup
         }
     }
 
+    public static void UnscheduleCharge()
+    {
+        using (TaskService taskService = new TaskService())
+        {
+            try
+            {
+                taskService.RootFolder.DeleteTask(chargeTaskName);
+            }
+            catch (Exception e)
+            {
+                Logger.WriteLine("Can't remove charge limit task: " + e.Message);
+            }
+        }
+    }
+
+    public static void ScheduleEcoMode()
+    {
+        if (strExeFilePath is null) return;
+
+        using (TaskDefinition td = TaskService.Instance.NewTask())
+        {
+            td.RegistrationInfo.Description = "G-Helper Switch to GPU Eco Mode (one-time)";
+            td.Actions.Add(strExeFilePath, "gpu-eco");
+
+            if (ProcessHelper.IsUserAdministrator())
+            {
+                td.Triggers.Add(new BootTrigger());
+                td.Triggers.Add(new EventTrigger
+                {
+                    Subscription = "<QueryList><Query Id='0' Path='System'><Select Path='System'>*[System[Provider[@Name='Microsoft-Windows-Kernel-Boot'] and EventID=27]]</Select></Query></QueryList>"
+                });
+                td.Principal.UserId = "SYSTEM";
+                td.Principal.LogonType = TaskLogonType.ServiceAccount;
+            }
+            else
+            {
+                td.Triggers.Add(new LogonTrigger { UserId = WindowsIdentity.GetCurrent().Name, Delay = TimeSpan.FromSeconds(5) });
+                td.Principal.LogonType = TaskLogonType.InteractiveToken;
+            }
+
+            td.Settings.StopIfGoingOnBatteries = false;
+            td.Settings.DisallowStartIfOnBatteries = false;
+            td.Settings.ExecutionTimeLimit = TimeSpan.FromMinutes(2);
+            td.Settings.MultipleInstances = TaskInstancesPolicy.IgnoreNew;
+
+            try
+            {
+                TaskService.Instance.RootFolder.RegisterTaskDefinition(ecoTaskName, td);
+                Logger.WriteLine("One-time eco-mode task scheduled: " + strExeFilePath);
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteLine("Can't create eco-mode task: " + ex.Message);
+            }
+        }
+    }
+
+    public static void UnscheduleEcoMode()
+    {
+        ProcessHelper.RunSilent("powershell.exe", $"-NoProfile -Command \"Start-Sleep 3; schtasks /delete /tn {ecoTaskName} /f\"");
+    }
+
     public static void Schedule()
     {
 
@@ -210,10 +258,9 @@ public class Startup
         }
 
         ScheduleCharge();
-
     }
 
-    public static void UnSchedule()
+    public static void Unschedule()
     {
         using (TaskService taskService = new TaskService())
         {

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -66,6 +66,18 @@ namespace GHelper
 
             if (action == "gpu-eco")
             {
+                if (!acpi.IsConnected())
+                {
+                    DialogResult dialogResult = MessageBox.Show(Properties.Strings.ACPIError, Properties.Strings.AlertDGPUTitle, MessageBoxButtons.YesNo);
+                    if (dialogResult == DialogResult.Yes)
+                    {
+                        Process.Start(new ProcessStartInfo("https://www.asus.com/support/FAQ/1047338/") { UseShellExecute = true });
+                    }
+
+                    Application.Exit();
+                    return;
+                }
+
                 Task.Run(async () =>
                 {
                     HardwareControl.RecreateGpuControl();

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -62,22 +62,39 @@ namespace GHelper
                 return;
             }
 
+            string language = AppConfig.GetString("language");
+            try
+            {
+                if (language != null && language.Length > 0)
+                    Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(language);
+                else
+                {
+                    var culture = CultureInfo.CurrentUICulture;
+                    if (culture.ToString() == "kr") culture = CultureInfo.GetCultureInfo("ko");
+                    Thread.CurrentThread.CurrentUICulture = culture;
+                }
+            }
+            catch
+            {
+                Logger.WriteLine("Unknown Language: " + language);
+            }
+
             acpi = new AsusACPI();
+
+            if (!acpi.IsConnected() && AppConfig.IsASUS() && !AppConfig.IsDesktop())
+            {
+                DialogResult dialogResult = MessageBox.Show(Properties.Strings.ACPIError, Properties.Strings.StartupError, MessageBoxButtons.YesNo);
+                if (dialogResult == DialogResult.Yes)
+                {
+                    Process.Start(new ProcessStartInfo("https://www.asus.com/support/FAQ/1047338/") { UseShellExecute = true });
+                }
+
+                Application.Exit();
+                return;
+            }
 
             if (action == "gpu-eco")
             {
-                if (!acpi.IsConnected())
-                {
-                    DialogResult dialogResult = MessageBox.Show(Properties.Strings.ACPIError, Properties.Strings.AlertDGPUTitle, MessageBoxButtons.YesNo);
-                    if (dialogResult == DialogResult.Yes)
-                    {
-                        Process.Start(new ProcessStartInfo("https://www.asus.com/support/FAQ/1047338/") { UseShellExecute = true });
-                    }
-
-                    Application.Exit();
-                    return;
-                }
-
                 Task.Run(async () =>
                 {
                     HardwareControl.RecreateGpuControl();
@@ -125,22 +142,6 @@ namespace GHelper
                 return;
             }
 
-            string language = AppConfig.GetString("language");
-            try
-            {
-                if (language != null && language.Length > 0)
-                    Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(language);
-                else
-                {
-                    var culture = CultureInfo.CurrentUICulture;
-                    if (culture.ToString() == "kr") culture = CultureInfo.GetCultureInfo("ko");
-                    Thread.CurrentThread.CurrentUICulture = culture;
-                }
-            } catch
-            {
-                Logger.WriteLine("Unknown Language: " + language);
-            }
-
             Logger.WriteLine("----------------------");
             Logger.WriteLine("App launched: " + AppConfig.GetModel() + " :" + Assembly.GetExecutingAssembly().GetName().Version.ToString() + CultureInfo.CurrentUICulture + (ProcessHelper.IsUserAdministrator() ? "." : ""));
 
@@ -161,18 +162,6 @@ namespace GHelper
             var startCount = AppConfig.Get("start_count") + 1;
             AppConfig.Set("start_count", startCount);
             Logger.WriteLine("Start Count: " + startCount);
-
-            if (!acpi.IsConnected() && AppConfig.IsASUS() && !AppConfig.IsDesktop())
-            {
-                DialogResult dialogResult = MessageBox.Show(Properties.Strings.ACPIError, Properties.Strings.StartupError, MessageBoxButtons.YesNo);
-                if (dialogResult == DialogResult.Yes)
-                {
-                    Process.Start(new ProcessStartInfo("https://www.asus.com/support/FAQ/1047338/") { UseShellExecute = true });
-                }
-
-                Application.Exit();
-                return;
-            }
 
             ProcessHelper.KillSmartDisplayControl();
             AsusService.StopOnStartup();

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -2,11 +2,13 @@ using GHelper.Ally;
 using GHelper.Battery;
 using GHelper.Display;
 using GHelper.Gpu;
+using GHelper.Gpu.NVidia;
 using GHelper.Helpers;
 using GHelper.Input;
 using GHelper.Mode;
 using GHelper.Overlay;
 using GHelper.Peripherals;
+using GHelper.Properties;
 using GHelper.USB;
 using Microsoft.Win32;
 using System.Diagnostics;
@@ -60,6 +62,57 @@ namespace GHelper
                 return;
             }
 
+            acpi = new AsusACPI();
+
+            if (action == "gpu-eco")
+            {
+                Task.Run(async () =>
+                {
+                    HardwareControl.RecreateGpuControl();
+                    HardwareControl.KillGPUApps();
+                    HardwareControl.DisposeGpuControl();
+                    if (AppConfig.IsNVPlatform()) NvidiaGpuControl.StopNVService();
+
+                    acpi.SetGPUEco(1);
+                    await Task.Delay(TimeSpan.FromMilliseconds(AppConfig.Get("refresh_delay", 500)));
+
+                    if (HardwareControl.GpuControl?.IsValid == true)
+                    {
+                        Logger.WriteLine("Eco half-state");
+                        if (AppConfig.IsEcoBootFix())
+                        {
+                            HardwareControl.DisposeGpuControl();
+                            acpi.DeviceSet(AsusACPI.GPUEco, 1, "GPUEco Force Fix");
+                        }
+                    }
+
+                    AppConfig.Set("gpu_mode", AsusACPI.GPUModeEco);
+                    Aura.CustomRGB.ApplyGPUColor(AsusACPI.GPUModeEco);
+                    try
+                    {
+                        ScreenControl.AutoScreen();
+                    }
+                    catch { }
+
+                    try
+                    {
+                        if (AppConfig.IsModeReapply())
+                        {
+                            await Task.Delay(TimeSpan.FromMilliseconds(1000));
+                            Program.modeControl.AutoPerformance();
+                        }
+                        else
+                        {
+                            Program.modeControl.SetGPUClocks(false);
+                        }
+                    }
+                    catch { }
+                }).Wait();
+
+                Startup.UnscheduleEcoMode();
+                return;
+            }
+
             string language = AppConfig.GetString("language");
             try
             {
@@ -96,8 +149,6 @@ namespace GHelper
             var startCount = AppConfig.Get("start_count") + 1;
             AppConfig.Set("start_count", startCount);
             Logger.WriteLine("Start Count: " + startCount);
-
-            acpi = new AsusACPI();
 
             if (!acpi.IsConnected() && AppConfig.IsASUS() && !AppConfig.IsDesktop())
             {

--- a/app/Settings.cs
+++ b/app/Settings.cs
@@ -1063,7 +1063,7 @@ namespace GHelper
             if (chk.Checked)
                 Startup.Schedule();
             else
-                Startup.UnSchedule();
+                Startup.Unschedule();
         }
 
         private void ButtonMatrix_Click(object? sender, EventArgs e)


### PR DESCRIPTION
1. When switching from Ultimate GPU Mode to Eco, it would previously restart and stay on Standard until you click Eco again. It now uses a self-deleting scheduled task to persist the state. When running with high privileges, the task runs on startup, otherwise runs on logon.
2. When switching between Ultimate and Standard/Eco GPU Mode, shutdown.exe is started to perform the restart. Previously, the cmd window would flash on the screen. Now it does not thanks to:
3. `ProcessHelper.RunSilent`, runs a command silently in the background with no window flashing
4. Changed some formatting in a couple of files, renamed `UnSchedule` to `Unschedule` in Startup.cs for more consistency.

Tested working on G16 2023